### PR TITLE
Support WireGuard by widening the OpenVPN backend to NetworkManager

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ a tool means writing one file and adding one line.
 | `VpnController.qml` | Owns the backends, picks the active one, enforces exclusivity, fetches the public IP |
 | `ProtonBackend.qml` | Proton VPN, via the `protonvpn` CLI |
 | `MullvadBackend.qml` | Mullvad, via the `mullvad` CLI |
-| `OpenVpnBackend.qml` | OpenVPN, via NetworkManager |
+| `NetworkManagerBackend.qml` | OpenVPN and WireGuard, via NetworkManager |
 | `Model.js` | Pure parsing and row-building. No QML, no side effects |
 
 ## The backend contract
@@ -25,7 +25,7 @@ duck-types, so a backend that omits something simply renders as blank.
 
 | Property | Meaning |
 |----------|---------|
-| `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `openvpn`) |
+| `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `networkmanager`) |
 | `label` | Name on the switcher chip and hero |
 | `glyph` | Nerd Font character for the hero icon |
 | `supportsFilter`, `filterPlaceholder` | Whether the panel shows its filter field |
@@ -52,9 +52,9 @@ duck-types, so a backend that omits something simply renders as blank.
 `toggles`.
 
 `toggleConnection()` is the backend's own idea of a default connection — Proton
-picks the fastest server; Mullvad reuses its stored relay constraint; OpenVPN
-connects the only profile if there is exactly one, and otherwise asks the user to
-pick.
+picks the fastest server; Mullvad reuses its stored relay constraint;
+NetworkManager connects the only profile if there is exactly one, and otherwise
+asks the user to pick.
 
 A backend may also expose `lockdownMode`, meaning "this tool blocks all traffic
 while it is disconnected". The controller warns about it before tearing that
@@ -139,14 +139,40 @@ tunnel is down; the setting itself is read separately with
 `mullvad lockdown-mode get`, because the case that matters — Mullvad connected,
 another backend about to take over — is exactly when the payload omits it.
 
-**OpenVPN discovery.** Two passes. `nmcli -t -f NAME,UUID,TYPE,ACTIVE connection
-show` gives every VPN-typed connection; a second call over just those uuids
+**Why OpenVPN and WireGuard share one backend.** Same listing call, same
+`connection up` verb, same teardown, same secret-agent problem, and no settings
+of their own on either side. Two chips would have meant two views of one
+manager. NetworkManager types them differently — OpenVPN is a `vpn` connection
+with a service-type plugin behind it, WireGuard is its own connection type with
+the keys in the profile — and that difference is carried on each row as `kind`,
+which picks the glyph and decides whether the username check applies.
+
+**NetworkManager discovery.** Two passes. `nmcli -t -f
+NAME,UUID,TYPE,ACTIVE,FILENAME connection show` gives every connection; the
+`vpn` and `wireguard` rows are kept. A second call over just the `vpn` uuids
 fetches `vpn.service-type` (to keep only OpenVPN ones) and `vpn.data` (to check
-for a username). The username matters because NetworkManager keeps it outside
-the secrets store, so `nmcli --ask` never prompts for it — a profile without one
-authenticates as the empty user and the server answers `AUTH_FAILED`. The
-backend detects that case and reports the fix instead of opening a terminal
-that cannot succeed.
+for a username). WireGuard rows skip that pass entirely — they are already known
+to be WireGuard and have no username to be missing. The username matters because
+NetworkManager keeps it outside the secrets store, so `nmcli --ask` never
+prompts for it — a profile without one authenticates as the empty user and the
+server answers `AUTH_FAILED`. The backend detects that case and reports the fix
+instead of opening a terminal that cannot succeed.
+
+**FILENAME is what keeps other tools' tunnels out.** When something brings up a
+WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the
+device and generates a volatile connection for it under `/run/NetworkManager/`.
+It is `wireguard`-typed and active, so a type filter alone would list Mullvad's
+tunnel as a NetworkManager profile: the same tunnel on two chips, and a
+`connection down` that would yank it out from under the daemon that owns it.
+Profiles the user imported live under `/etc`, so anything under `/run` is
+dropped. An nmcli too old to report FILENAME leaves it empty, which keeps the
+row rather than emptying the list.
+
+**Exclusivity inside the backend.** The controller enforces one tunnel across
+backends, but NetworkManager will happily run two of its own profiles at once,
+and picking one is never a request for both. So `connectTo` runs two commands
+when something else is up: down the active profile, then up the chosen one. A
+failed teardown still proceeds, for the same reason the controller's does.
 
 **Nerd Font glyphs** are built with `String.fromCodePoint` rather than pasted as
 literal characters, because editing tools routinely mangle multi-byte sequences

--- a/Model.js
+++ b/Model.js
@@ -8,6 +8,7 @@ var GLYPH_LOCK = String.fromCodePoint(0xF033E)
 var GLYPH_BOLT = String.fromCodePoint(0xF04C5)
 var GLYPH_DICE = String.fromCodePoint(0xF01D5)
 var GLYPH_SWAP = String.fromCodePoint(0xF04E1)
+var GLYPH_SHIELD = String.fromCodePoint(0xF0498)
 var GLYPH_CHEVRON_DOWN = String.fromCodePoint(0xF0140)
 var GLYPH_CHEVRON_UP = String.fromCodePoint(0xF0143)
 
@@ -295,7 +296,13 @@ function protonCountryTargets(countries, favorites, filter) {
   return favored.concat(rest)
 }
 
-// ---------------------------------------------------------------- OpenVPN
+// --------------------------------------------------------- NetworkManager
+//
+// OpenVPN and WireGuard both live here, because on a desktop both are
+// NetworkManager profiles: same listing call, same `connection up` verb, same
+// teardown. What differs is how NetworkManager types them — OpenVPN is a `vpn`
+// connection with a service-type plugin behind it, WireGuard is its own
+// connection type with the keys in the profile.
 
 // `nmcli -t` escapes literal colons as "\:", so split on the first unescaped
 // one rather than on every colon.
@@ -312,9 +319,25 @@ function unescapeNmcli(value) {
   return String(value || "").replace(/\\(.)/g, "$1")
 }
 
-// `nmcli -t -f NAME,UUID,TYPE,ACTIVE connection show` — one connection per
-// line. Only the `vpn` type can be an OpenVPN profile; `wireguard` and plain
-// devices are somebody else's business.
+// Generated on the fly for a device someone else brought up, rather than a
+// profile on disk. An older nmcli that does not report FILENAME leaves this
+// empty, in which case the connection is kept — better a stray row than a
+// backend that lists nothing at all.
+function isVolatileConnection(filename) {
+  return String(filename || "").indexOf("/run/") === 0
+}
+
+// `nmcli -t -f NAME,UUID,TYPE,ACTIVE,FILENAME connection show` — one connection
+// per line. Two types are tunnels: `vpn` (an OpenVPN profile, or another
+// plugin's, which the second pass sorts out) and `wireguard`. Ethernet, wifi,
+// bridges and the rest are somebody else's business.
+//
+// FILENAME is what keeps other tools' tunnels out. When something brings up a
+// WireGuard interface itself — Mullvad's `wg0-mullvad`, say — NetworkManager
+// adopts the device and generates a volatile connection for it under
+// `/run/NetworkManager/`. Listing that would put the same tunnel on two chips,
+// and taking it down through nmcli would yank it out from under the tool that
+// owns it. Profiles the user actually imported are stored under `/etc`.
 function parseNmcliConnections(raw) {
   var connections = []
   var lines = String(raw || "").split("\n")
@@ -324,15 +347,22 @@ function parseNmcliConnections(raw) {
 
     var fields = []
     var rest = line
-    for (var f = 0; f < 3; f++) {
+    for (var f = 0; f < 4; f++) {
       var pair = splitNmcliLine(rest)
       fields.push(pair[0])
       rest = pair[1]
     }
     fields.push(unescapeNmcli(rest))
 
-    if (fields[2] !== "vpn") continue
-    connections.push({ name: fields[0], uuid: fields[1], active: fields[3] === "yes" })
+    if (fields[2] !== "vpn" && fields[2] !== "wireguard") continue
+    if (isVolatileConnection(fields[4])) continue
+    connections.push({
+      name: fields[0],
+      uuid: fields[1],
+      // "vpn" here means "needs the second pass to say which plugin".
+      kind: fields[2] === "wireguard" ? "wireguard" : "vpn",
+      active: fields[3] === "yes"
+    })
   }
   return connections
 }
@@ -388,42 +418,59 @@ function isOpenVpnService(serviceType) {
   return String(serviceType || "").toLowerCase().indexOf("openvpn") !== -1
 }
 
-function openVpnTargets(profiles) {
+function isWireGuard(profile) {
+  return profile && profile.kind === "wireguard"
+}
+
+function nmKindLabel(profile) {
+  return isWireGuard(profile) ? "WireGuard" : "OpenVPN"
+}
+
+// The glyph carries the kind, since the rows otherwise look identical and the
+// two behave differently the moment credentials come up.
+function nmTargets(profiles) {
   var targets = []
   for (var i = 0; i < profiles.length; i++) {
     var profile = profiles[i]
+    var wireguard = isWireGuard(profile)
+
     targets.push({
       key: "profile:" + profile.uuid,
       label: profile.name,
       detail: profile.active
         ? "Connected"
-        : (profile.hasUsername ? "NetworkManager profile" : "No username set"),
-      glyph: GLYPH_LOCK,
+        // Only OpenVPN can be missing a username: WireGuard keeps its keys in
+        // the profile, so there is nothing for the user to have left out.
+        : (wireguard || profile.hasUsername ? nmKindLabel(profile) + " profile" : "No username set"),
+      glyph: wireguard ? GLYPH_SHIELD : GLYPH_LOCK,
       args: ["connection", "up", "uuid", profile.uuid],
       uuid: profile.uuid,
+      kind: profile.kind,
       hasUsername: profile.hasUsername
     })
   }
   return targets
 }
 
-function openVpnSummary(profiles) {
+function nmSummary(profiles) {
   for (var i = 0; i < profiles.length; i++) {
     if (profiles[i].active) return profiles[i].name
   }
   return profiles.length === 0 ? "No profiles" : "Not connected"
 }
 
-function openVpnDetails(profiles) {
+function nmDetails(profiles) {
   var rows = []
   for (var i = 0; i < profiles.length; i++) {
-    if (profiles[i].active) rows.push(detail("Profile", profiles[i].name))
+    if (!profiles[i].active) continue
+    rows.push(detail("Profile", profiles[i].name))
+    rows.push(detail("Type", nmKindLabel(profiles[i])))
   }
   if (rows.length > 0) rows.push(detail("Managed by", "NetworkManager"))
   return rows
 }
 
-function activeOpenVpnProfile(profiles) {
+function activeNmProfile(profiles) {
   for (var i = 0; i < profiles.length; i++) {
     if (profiles[i].active) return profiles[i]
   }

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -2,9 +2,10 @@ import QtQuick
 import Quickshell.Io
 import "Model.js" as Model
 
-// OpenVPN backend. OpenVPN itself has no session daemon to ask, so the profiles
-// come from NetworkManager, which is what imports and stores .ovpn files on a
-// desktop. Implements the backend contract documented in VpnController.qml.
+// NetworkManager backend: every tunnel NetworkManager owns, which on a desktop
+// means OpenVPN and WireGuard. Neither has a session daemon of its own to ask —
+// NetworkManager is what imports and stores both `.ovpn` files and WireGuard
+// configs. Implements the backend contract documented in VpnController.qml.
 Item {
   id: root
   visible: false
@@ -12,8 +13,8 @@ Item {
   property var settings: ({})
   property string filter: ""
 
-  readonly property string backendId: "openvpn"
-  readonly property string label: "OpenVPN"
+  readonly property string backendId: "networkmanager"
+  readonly property string label: "NetworkManager"
   readonly property string glyph: Model.GLYPH_VPN
   readonly property bool supportsFilter: false
   readonly property string filterPlaceholder: ""
@@ -24,9 +25,15 @@ Item {
   property string lastError: ""
 
   property bool _nmcliPresent: false
+  // One tunnel tool is enough: a machine with only WireGuard installed still
+  // gets the chip, and a profile of a kind you cannot run simply never appears.
   property bool _openvpnPresent: false
+  property bool _wireguardPresent: false
   property int _desired: -1
   property var _pendingTarget: null
+  // Connecting can take two commands — down the profile that is up, then up the
+  // one that was asked for. "" when nothing is in flight.
+  property string _stage: ""
 
   // NetworkManager refuses to activate a profile whose secrets it does not
   // hold, and the Omarchy shell runs no NM secret agent to prompt with. The
@@ -34,15 +41,16 @@ Item {
   // `nmcli --ask` can collect the credentials itself.
   signal authRequired(string command)
 
-  readonly property bool _activeNow: Model.activeOpenVpnProfile(profiles) !== null
+  readonly property bool _activeNow: Model.activeNmProfile(profiles) !== null
   readonly property bool connected: _desired === -1 ? _activeNow : (_desired === 1)
-  readonly property bool busy: connectProcess.running || listProcess.running || typesProcess.running
-  readonly property string summary: Model.openVpnSummary(profiles)
-  readonly property var details: Model.openVpnDetails(profiles)
-  readonly property var targets: Model.openVpnTargets(profiles)
-  readonly property string emptyText: "No OpenVPN profiles yet. Import one with: nmcli connection import type openvpn file <config.ovpn>"
+  readonly property bool _working: connectProcess.running || chainTimer.running || _stage !== ""
+  readonly property bool busy: _working || listProcess.running || typesProcess.running
+  readonly property string summary: Model.nmSummary(profiles)
+  readonly property var details: Model.nmDetails(profiles)
+  readonly property var targets: Model.nmTargets(profiles)
+  readonly property string emptyText: "No profiles yet. Import one with: nmcli connection import type openvpn file <config.ovpn> — or type wireguard file <config.conf>"
   readonly property string currentKey: {
-    var profile = Model.activeOpenVpnProfile(profiles)
+    var profile = Model.activeNmProfile(profiles)
     return profile ? "profile:" + profile.uuid : ""
   }
 
@@ -52,13 +60,14 @@ Item {
   }
 
   function detect() {
-    if (nmcliProbe.running || openvpnProbe.running) return
+    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
     nmcliProbe.running = true
     openvpnProbe.running = true
+    wireguardProbe.running = true
   }
 
   function _updateDetected() {
-    root.detected = _nmcliPresent && _openvpnPresent
+    root.detected = _nmcliPresent && (_openvpnPresent || _wireguardPresent)
     if (root.detected) root.refresh()
   }
 
@@ -68,13 +77,14 @@ Item {
   }
 
   function connectTo(target) {
-    if (!detected || connectProcess.running || !target) return
+    if (!detected || _working || !target) return
 
     // `nmcli --ask` prompts for secrets only, and the OpenVPN username is not
     // one — it lives in vpn.data. Without it the profile authenticates as the
     // empty user and the server rejects it, so point at the fix rather than
-    // open a password prompt that cannot succeed.
-    if (target.hasUsername === false) {
+    // open a password prompt that cannot succeed. WireGuard has no username at
+    // all, so this is not its problem.
+    if (target.kind !== "wireguard" && target.hasUsername === false) {
       lastError = "\"" + target.label + "\" has no username. Set one with: nmcli connection modify "
         + target.label + " +vpn.data username=<user>"
       return
@@ -84,6 +94,28 @@ Item {
     _pendingTarget = target
     lastError = ""
     actionStatus = "Connecting to " + target.label + "…"
+
+    // NetworkManager will happily run two tunnels at once, and picking one
+    // profile is never a request for both. The controller only enforces this
+    // between backends, so the profiles inside this one take each other down.
+    var active = Model.activeNmProfile(profiles)
+    if (active && active.uuid !== target.uuid) {
+      _stage = "handover"
+      connectProcess.command = ["nmcli", "connection", "down", "uuid", active.uuid]
+    } else {
+      _stage = "final"
+      connectProcess.command = ["nmcli"].concat(target.args || [])
+    }
+    connectProcess.running = true
+  }
+
+  function connectPending() {
+    var target = root._pendingTarget
+    if (!target) {
+      root._stage = ""
+      return
+    }
+    root._stage = "final"
     connectProcess.command = ["nmcli"].concat(target.args || [])
     connectProcess.running = true
   }
@@ -93,12 +125,13 @@ Item {
   }
 
   function disconnect() {
-    if (!detected || connectProcess.running) return
+    if (!detected || _working) return
 
-    var active = Model.activeOpenVpnProfile(profiles)
+    var active = Model.activeNmProfile(profiles)
     if (!active) return
 
     _desired = 0
+    _stage = "final"
     lastError = ""
     actionStatus = "Disconnecting…"
     connectProcess.command = ["nmcli", "connection", "down", "uuid", active.uuid]
@@ -112,14 +145,14 @@ Item {
     }
     // One profile is an unambiguous "the VPN"; several need a pick.
     if (profiles.length === 1) connectTo(targets[0])
-    else if (profiles.length === 0) actionStatus = "Import an OpenVPN profile first"
+    else if (profiles.length === 0) actionStatus = "Import a profile first"
     else actionStatus = "Pick a profile below"
     actionStatusTimer.restart()
   }
 
   function applyProfiles(list) {
     root.profiles = list
-    if (_desired !== -1 && (Model.activeOpenVpnProfile(list) !== null) === (_desired === 1)) _desired = -1
+    if (_desired !== -1 && (Model.activeNmProfile(list) !== null) === (_desired === 1)) _desired = -1
   }
 
   Timer {
@@ -127,6 +160,15 @@ Item {
     interval: 2600
     repeat: false
     onTriggered: root.actionStatus = ""
+  }
+
+  // Starting the second command from inside onExited would re-enter the process
+  // that is still finishing, so the handover hops through the event loop first.
+  Timer {
+    id: chainTimer
+    interval: 0
+    repeat: false
+    onTriggered: root.connectPending()
   }
 
   // NetworkManager reports the new state a beat after nmcli returns.
@@ -167,11 +209,26 @@ Item {
     }
   }
 
-  // Every VPN-typed connection, whichever plugin backs it.
+  // `wg` comes with wireguard-tools. The kernel module is what actually carries
+  // the tunnel, but NetworkManager loads that itself, and a box with the tools
+  // installed is a box where a WireGuard profile is meant to work.
+  Process {
+    id: wireguardProbe
+    command: ["omarchy-cmd-present", "wg"]
+    running: true
+    onExited: function(exitCode) {
+      root._wireguardPresent = exitCode === 0
+      root._updateDetected()
+    }
+  }
+
+  // Every tunnel-shaped connection: `vpn` whichever plugin backs it, plus
+  // `wireguard`, which NetworkManager types as its own thing rather than as a
+  // VPN plugin.
   Process {
     id: listProcess
     running: false
-    command: ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE", "connection", "show"]
+    command: ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE,FILENAME", "connection", "show"]
     stdout: StdioCollector { id: listStdout; waitForEnd: true }
     stderr: StdioCollector { id: listStderr; waitForEnd: true }
     property var pending: []
@@ -188,10 +245,23 @@ Item {
         return
       }
 
-      // Second pass: only the OpenVPN ones survive, and the service type and
-      // username are per-connection detail the summary listing does not carry.
+      // Second pass, over the `vpn` rows only: which plugin backs them, and
+      // whether a username is set. WireGuard rows need neither — they are
+      // already known to be WireGuard, and their keys live in the profile — so
+      // asking about them would only fetch empty fields.
       var command = ["nmcli", "-t", "-f", "connection.uuid,vpn.service-type,vpn.data", "connection", "show"]
-      for (var i = 0; i < listProcess.pending.length; i++) command.push(listProcess.pending[i].uuid)
+      var asked = 0
+      for (var i = 0; i < listProcess.pending.length; i++) {
+        if (listProcess.pending[i].kind !== "vpn") continue
+        command.push(listProcess.pending[i].uuid)
+        asked += 1
+      }
+
+      if (asked === 0) {
+        root.applyProfiles(listProcess.pending)
+        return
+      }
+
       typesProcess.command = command
       typesProcess.running = true
     }
@@ -209,16 +279,25 @@ Item {
       }
 
       var details = Model.parseNmcliVpnDetails(String(typesStdout.text || ""))
-      var openVpnProfiles = []
+      var usable = []
       for (var i = 0; i < listProcess.pending.length; i++) {
         var candidate = listProcess.pending[i]
+
+        // WireGuard skipped the second pass, so it is kept as it stands. A
+        // `vpn` row survives only if OpenVPN is the plugin behind it — some
+        // other plugin's profile is not something this backend can drive.
+        if (candidate.kind === "wireguard") {
+          usable.push(candidate)
+          continue
+        }
+
         var detail = details[candidate.uuid]
         if (!detail || !Model.isOpenVpnService(detail.serviceType)) continue
 
         candidate.hasUsername = detail.hasUsername
-        openVpnProfiles.push(candidate)
+        usable.push(candidate)
       }
-      root.applyProfiles(openVpnProfiles)
+      root.applyProfiles(usable)
     }
   }
 
@@ -230,6 +309,17 @@ Item {
     stderr: StdioCollector { id: connectStderr; waitForEnd: true }
     onExited: function(exitCode) {
       var output = String(connectStderr.text || "") + "\n" + String(connectStdout.text || "")
+
+      // The old tunnel is down (or refused to come down, which is not a reason
+      // to swallow the connect the user asked for). Either way, bring up the
+      // one they picked.
+      if (root._stage === "handover") {
+        root._stage = ""
+        chainTimer.restart()
+        return
+      }
+
+      root._stage = ""
       if (exitCode !== 0) {
         root._desired = -1
         var target = root._pendingTarget

--- a/Panel.qml
+++ b/Panel.qml
@@ -39,7 +39,7 @@ Panel {
   readonly property bool filterVisible: backend !== null && backend.supportsFilter
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
   readonly property string statusLine: {
-    if (!backend) return "Install Proton VPN, Mullvad, or OpenVPN to use this widget."
+    if (!backend) return "Install Proton VPN, Mullvad, OpenVPN, or WireGuard to use this widget."
     return backend.actionStatus !== "" ? backend.actionStatus : backend.lastError
   }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A VPN widget for the Omarchy bar. One icon shows whether you are behind a
 tunnel; one panel connects, disconnects, and switches between the VPN tools you
 actually have installed.
 
-It supports **Proton VPN**, **Mullvad**, and **OpenVPN** today. Only the tools
+It supports **Proton VPN**, **Mullvad**, and the **OpenVPN** and **WireGuard**
+profiles NetworkManager holds. Only the tools
 found on your machine appear — install none and the widget tells you so; install
 several and a chip row lets you switch between them.
 
@@ -55,8 +56,9 @@ Inside the panel:
   one back for you.
 - **The list** is what you can connect to: for Proton VPN, fastest / P2P /
   random / Secure Core followed by every country; for Mullvad, any location
-  followed by every country it has relays in; for OpenVPN, your NetworkManager
-  profiles. A check mark marks where you are connected.
+  followed by every country it has relays in; for NetworkManager, your OpenVPN
+  and WireGuard profiles, told apart by their icon. A check mark marks where you
+  are connected.
 
 Keyboard, once the panel is open: `j`/`k` or arrows move — through the header,
 the chips, the name row, the settings switches if they are open, then the list —
@@ -74,8 +76,8 @@ Omarchy with its Quickshell desktop, plus at least one of:
 - **Proton VPN** — the `protonvpn` CLI, signed in (`protonvpn signin`).
 - **Mullvad** — the `mullvad` CLI with `mullvad-daemon` running, logged in
   (`mullvad account login <number>`).
-- **OpenVPN** — `openvpn` and `nmcli`, with at least one profile imported into
-  NetworkManager.
+- **OpenVPN or WireGuard** — `nmcli`, plus `openvpn` or `wg` (wireguard-tools),
+  with at least one profile imported into NetworkManager.
 
 ## Settings
 
@@ -109,20 +111,28 @@ own. That switch is in the panel, or:
 mullvad lockdown-mode set off
 ```
 
-## OpenVPN profiles
+## NetworkManager profiles
 
-OpenVPN has no daemon to ask, so the widget reads your profiles from
-NetworkManager — the thing that imports and stores `.ovpn` files on a desktop.
-Import one with:
+Neither OpenVPN nor WireGuard has a daemon of its own to ask, so both come from
+NetworkManager — the thing that imports and stores tunnel configs on a desktop.
+They share one chip, and the row icon says which is which. Import one with:
 
 ```bash
 nmcli connection import type openvpn file ~/Downloads/office.ovpn
+nmcli connection import type wireguard file ~/Downloads/home.conf
 ```
 
-A tunnel you started some other way (a bare `openvpn` process, or
-`openvpn-client@.service`) will not be listed.
+A tunnel you started some other way is not listed: a bare `openvpn` process,
+`openvpn-client@.service`, or a `wg-quick@` unit. Neither is a tunnel another
+tool on this list owns — Mullvad brings up its own WireGuard interface, and
+NetworkManager adopts it, but that belongs on the Mullvad chip and appears only
+there.
 
-A freshly imported profile usually has no credentials saved, and there is no
+Picking a profile takes down whichever one is already up. NetworkManager is
+happy to run two tunnels at once; that is never what clicking a second profile
+means.
+
+A freshly imported OpenVPN profile usually has no credentials saved, and there is no
 password prompt running inside the Omarchy shell. To make a profile connect in
 one click:
 
@@ -139,6 +149,10 @@ by root only.
 
 Without those, clicking a profile opens a terminal running
 `nmcli --ask connection up …` so you can type the password there.
+
+WireGuard needs none of this: its keys live in the profile. The one exception is
+a profile whose `wireguard.private-key-flags` were set to ask an agent, which
+lands in the same terminal.
 
 If you are importing a Proton `.ovpn`: the username and password are the
 **OpenVPN/IKEv2** credentials from your Proton dashboard, not your Proton
@@ -162,7 +176,7 @@ come back after a reboot).
 **Nothing appears in the bar.** Confirm the plugin is enabled with
 `omarchy plugin list`, then `omarchy restart shell`.
 
-**Proton and OpenVPN fight each other.** Proton's daemon tears down foreign
+**Proton and NetworkManager fight each other.** Proton's daemon tears down foreign
 tunnels when it connects. The widget already shuts other tools down before
 connecting, so use the widget rather than mixing it with the Proton app.
 
@@ -174,7 +188,7 @@ it:
 ```bash
 omarchy-shell jkoestinger.vpn status       # "Proton VPN · CH#1129 · Zurich, Switzerland"
 omarchy-shell jkoestinger.vpn ip           # current public address
-omarchy-shell jkoestinger.vpn backends     # "proton mullvad openvpn"
+omarchy-shell jkoestinger.vpn backends     # "proton mullvad networkmanager"
 omarchy-shell jkoestinger.vpn use mullvad  # switch the panel's active tool
 omarchy-shell jkoestinger.vpn connect CH   # country code, profile name, or row key
 omarchy-shell jkoestinger.vpn quickconnect # each tool's default connection

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -29,7 +29,7 @@ Item {
   // Set when the user picks a chip; "" follows `preferredBackend`.
   property string selectedId: ""
 
-  readonly property var backends: [proton, mullvad, openvpn]
+  readonly property var backends: [proton, mullvad, networkManager]
   readonly property var availableBackends: backends.filter(function(backend) { return backend.detected })
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 15, 5, 600)
 
@@ -148,7 +148,7 @@ Item {
     var preferred = String(setting("preferredBackend", "Auto"))
     if (preferred === "Proton VPN") return "proton"
     if (preferred === "Mullvad") return "mullvad"
-    if (preferred === "OpenVPN") return "openvpn"
+    if (preferred === "NetworkManager") return "networkmanager"
     return ""
   }
 
@@ -248,8 +248,8 @@ Item {
     settings: root.settings
   }
 
-  OpenVpnBackend {
-    id: openvpn
+  NetworkManagerBackend {
+    id: networkManager
     settings: root.settings
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "VPN",
-    "description": "Detects installed VPN tools (Proton VPN, Mullvad, OpenVPN) and switches between them from one bar icon.",
+    "description": "Detects installed VPN tools (Proton VPN, Mullvad, and NetworkManager's OpenVPN and WireGuard profiles) and switches between them from one bar icon.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",
@@ -37,7 +37,7 @@
         "key": "preferredBackend",
         "type": "enum",
         "label": "VPN tool shown first",
-        "options": ["Auto", "Proton VPN", "Mullvad", "OpenVPN"],
+        "options": ["Auto", "Proton VPN", "Mullvad", "NetworkManager"],
         "defaultValue": "Auto",
         "description": "Auto picks whichever detected tool is connected, otherwise the first one found."
       },


### PR DESCRIPTION
Closes #4.

OpenVPN and WireGuard turned out to be the same backend wearing different hats — same listing call, same `connection up` verb, same teardown, same secret-agent problem, and no tool settings on either side. So `OpenVpnBackend.qml` becomes `NetworkManagerBackend.qml` and lists both kinds on one chip, with the row glyph carrying the difference.

## What changed

- **Discovery** keeps `vpn` and `wireguard` rows. The second pass over `vpn.service-type` and `vpn.data` runs only on the `vpn` uuids — WireGuard is already known to be WireGuard, and its keys live in the profile, so it has no username to be missing and the username warning does not apply to it.
- **Detection** is now `nmcli` plus `openvpn` *or* `wg`, so a machine with only WireGuard installed still gets the chip.
- **`backendId`** goes from `openvpn` to `networkmanager`, and the `preferredBackend` option from `"OpenVPN"` to `"NetworkManager"`. No migration path, since the plugin has not been distributed.

## Two things the testing surfaced

**Two NetworkManager tunnels could be up at once.** The controller enforces exclusivity between backends, but nothing stopped two of its own profiles running together — reproduced by connecting one WireGuard profile while another was up. `connectTo` now downs the active profile first and brings up the chosen one after, chained through the event loop the way Mullvad's two-step connect is. A failed teardown still proceeds, for the same reason the controller's does.

**Mullvad's own tunnel was showing up as a profile.** When a daemon brings up a WireGuard interface itself, NetworkManager adopts the device and generates a volatile connection for it — `wireguard`-typed and active, so the type filter alone listed it. That would have put one tunnel on two chips and let `connection down` yank it out from under the daemon that owns it. `FILENAME` separates them: generated connections live under `/run/NetworkManager/`, imported profiles under `/etc`. An nmcli too old to report the field keeps the row rather than emptying the list.

## Verification

Against a real WireGuard profile plus two OpenVPN ones and a throwaway WireGuard profile (since deleted):

- both kinds listed with the right icon, detail line, and check mark
- connect and disconnect through the widget
- switching profiles leaves exactly one tunnel up
- cross-backend exclusivity still tears the WireGuard tunnel down before Mullvad connects
- with Mullvad connected, `wg0-mullvad` is absent from the list and the chip reads "Not connected"
- public IP invalidates on each change

Parsers were unit-tested against live `nmcli` output, escaped-colon connection names, and an nmcli with no `FILENAME` column. `omarchy plugin validate` passes; no QML errors in the debug shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
