### PR TITLE
feat: hide tools with nothing to offer, add a widget settings view

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ duck-types, so a backend that omits something simply renders as blank.
 
 | Property | Meaning |
 |----------|---------|
-| `detected` | Tool is installed and usable. Everything else is ignored until this is true |
+| `detected` | Tool is installed and has something to offer. Everything else is ignored until this is true |
 | `connected` | A tunnel is up |
 | `summary` | One line under the hero title |
 | `details` | `[{ label, value }]` rows shown while connected |
@@ -59,6 +59,11 @@ asks the user to pick.
 A backend may also expose `lockdownMode`, meaning "this tool blocks all traffic
 while it is disconnected". The controller warns about it before tearing that
 backend down for another one.
+
+It may also expose `setupHint`: one line explaining why it is not `detected`
+and what would change that. The panel shows the first non-empty hint in place
+of its own "install a VPN tool" line, which is the wrong advice for a tool that
+is installed and merely has nothing to connect to yet.
 
 ## Adding a backend
 
@@ -112,6 +117,25 @@ state lives on the panel, so it survives a close and reopen but not a shell
 restart, and folding the drawer while the cursor is inside it moves the cursor
 back to the hero rather than stranding it.
 
+**Two kinds of settings, two places.** The drawer above holds the *tool's*
+settings, which the widget only reflects. The gear in the header holds the
+*widget's* own, which it owns and must persist — currently one switch per
+detected tool. It writes through `bar.shell.updateEntryInline(moduleName,
+settings)` into this widget's entry in `~/.config/omarchy/shell.json`, the same
+file and entry Omarchy's settings dialog edits, so the two never disagree.
+`settings` arrives holding only the inline overrides, so writing it back cannot
+bake today's defaults into the config.
+
+Hidden tools are dropped from `availableBackends`: no chip, no polling, no
+weight in the bar icon, and exclusivity never tears them down. They are still
+probed, since the settings view has to list a hidden tool for you to switch it
+back on, and `detectedBackends` — everything present, hidden or not — is what
+that view renders. Hiding is a view, not a drawer: it replaces the body, because
+nothing in the connect list means anything while you are deciding which tools
+the widget should know about. It resets on close, unlike the tool drawer, and
+the gear stays reachable with the master switch gone so a widget with everything
+hidden is not a dead end.
+
 While a switch is in flight it shows the position the user just asked for, with
 `busy` set. The optimistic value is dropped only for the keys the tool has since
 agreed with, so a poll landing mid-flight cannot flick the other switches back —
@@ -157,6 +181,17 @@ NetworkManager keeps it outside the secrets store, so `nmcli --ask` never
 prompts for it — a profile without one authenticates as the empty user and the
 server answers `AUTH_FAILED`. The backend detects that case and reports the fix
 instead of opening a terminal that cannot succeed.
+
+**Eligibility, not just installation.** NetworkManager ships on every desktop,
+so "nmcli is here" says nothing about whether this machine has a tunnel to
+offer. It is `detected` only while at least one eligible profile exists — one
+whose kind matches an installed tool (`openvpn` for OpenVPN profiles, `wg` for
+WireGuard ones), since NetworkManager lists an OpenVPN profile whether or not
+anything can run it. With no eligible profile the backend disappears, and with
+it the chip, the hero, and the empty list they led to; the import instructions
+move to the panel's `setupHint` line so nothing is lost. Because `detected` now
+follows the profile list, `detect()` stays callable every poll: the binary
+probes run once, and after that it is a plain `refresh()`.
 
 **FILENAME is what keeps other tools' tunnels out.** When something brings up a
 WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the

--- a/Model.js
+++ b/Model.js
@@ -11,6 +11,7 @@ var GLYPH_SWAP = String.fromCodePoint(0xF04E1)
 var GLYPH_SHIELD = String.fromCodePoint(0xF0498)
 var GLYPH_CHEVRON_DOWN = String.fromCodePoint(0xF0140)
 var GLYPH_CHEVRON_UP = String.fromCodePoint(0xF0143)
+var GLYPH_COG = String.fromCodePoint(0xF0493)
 
 // ----------------------------------------------------------------- shared
 
@@ -37,6 +38,36 @@ function applyPendingToggles(toggles, pending) {
     if (pending[entry.key] === undefined) return entry
     return { key: entry.key, label: entry.label, detail: entry.detail, value: pending[entry.key] === true, busy: true }
   })
+}
+
+// --------------------------------------------------------- widget settings
+
+// Which tools the user told the widget to ignore, stored as one comma-separated
+// string so the setting stays hand-editable in shell.json and in Omarchy's own
+// settings dialog, which has no array field.
+function parseBackendIds(raw) {
+  var ids = []
+  var parts = String(raw || "").split(",")
+  for (var i = 0; i < parts.length; i++) {
+    var id = parts[i].trim().toLowerCase()
+    if (id !== "" && ids.indexOf(id) === -1) ids.push(id)
+  }
+  return ids
+}
+
+function joinBackendIds(ids) {
+  return ids.join(",")
+}
+
+function toggleBackendId(ids, id) {
+  var next = []
+  var found = false
+  for (var i = 0; i < ids.length; i++) {
+    if (ids[i] === id) found = true
+    else next.push(ids[i])
+  }
+  if (!found) next.push(id)
+  return next
 }
 
 // ------------------------------------------------------------ Proton VPN

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -19,7 +19,6 @@ Item {
   readonly property bool supportsFilter: false
   readonly property string filterPlaceholder: ""
 
-  property bool detected: false
   property var profiles: []
   property string actionStatus: ""
   property string lastError: ""
@@ -29,6 +28,18 @@ Item {
   // gets the chip, and a profile of a kind you cannot run simply never appears.
   property bool _openvpnPresent: false
   property bool _wireguardPresent: false
+  property int _probesDone: 0
+  property bool _probed: false
+
+  readonly property bool _toolsPresent: _nmcliPresent && (_openvpnPresent || _wireguardPresent)
+  // Having the tools is not having anything to connect to. NetworkManager is
+  // the one backend whose list can be legitimately empty on a working install,
+  // and a chip leading to an empty list is a chip worth not drawing.
+  readonly property bool detected: _toolsPresent && profiles.length > 0
+
+  // Said instead of the panel's "install a VPN tool" line, which is unhelpful
+  // advice for someone who has the tools and only lacks a profile.
+  readonly property string setupHint: _toolsPresent && profiles.length === 0 ? emptyText : ""
   property int _desired: -1
   property var _pendingTarget: null
   // Connecting can take two commands — down the profile that is up, then up the
@@ -59,20 +70,30 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
+  // `detected` now depends on the profile list, so the controller keeps calling
+  // detect() on a machine that has the tools and no profiles. The binaries do
+  // not come and go; once probed, this is a plain refresh rather than three
+  // more processes every poll.
   function detect() {
+    if (_probed) {
+      refresh()
+      return
+    }
     if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
   }
 
-  function _updateDetected() {
-    root.detected = _nmcliPresent && (_openvpnPresent || _wireguardPresent)
-    if (root.detected) root.refresh()
+  function _probeFinished() {
+    root._probesDone += 1
+    if (root._probesDone < 3) return
+    root._probed = true
+    if (root._toolsPresent) root.refresh()
   }
 
   function refresh() {
-    if (!detected || listProcess.running) return
+    if (!_toolsPresent || listProcess.running) return
     listProcess.running = true
   }
 
@@ -150,9 +171,20 @@ Item {
     actionStatusTimer.restart()
   }
 
+  // A profile is only eligible if the tool that carries its kind is installed:
+  // NetworkManager lists an OpenVPN profile whether or not anything can run it.
+  function runnable(profile) {
+    return profile.kind === "wireguard" ? _wireguardPresent : _openvpnPresent
+  }
+
   function applyProfiles(list) {
-    root.profiles = list
-    if (_desired !== -1 && (Model.activeNmProfile(list) !== null) === (_desired === 1)) _desired = -1
+    var eligible = []
+    for (var i = 0; i < list.length; i++) {
+      if (runnable(list[i])) eligible.push(list[i])
+    }
+
+    root.profiles = eligible
+    if (_desired !== -1 && (Model.activeNmProfile(eligible) !== null) === (_desired === 1)) _desired = -1
   }
 
   Timer {
@@ -195,7 +227,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._nmcliPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 
@@ -205,7 +237,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._openvpnPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 
@@ -218,7 +250,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._wireguardPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -17,6 +17,12 @@ Panel {
   property string focusSection: "rows"
   property int rowIndex: 0
   property int toggleIndex: 0
+  // Inside the header: 0 is the gear, 1 the master switch.
+  property int headerIndex: 1
+  // The widget's own settings, as opposed to the tool's. They replace the body
+  // rather than fold out below it: nothing in the connect list means anything
+  // while you are deciding which tools the widget should know about.
+  property bool providersOpen: false
   // Settings start folded away: they are the part of the panel you touch once
   // and then leave alone. Kept for the session, not per open.
   property bool settingsExpanded: false
@@ -29,17 +35,39 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   readonly property var backend: vpn.active
-  readonly property var rows: backend ? backend.targets : []
+  // One tool per row, switch on the right: the whole widget setting is which
+  // of the tools on this machine it should bother with.
+  readonly property var providerRows: vpn.detectedBackends.map(function(entry) {
+    var hidden = vpn.isHidden(entry.backendId)
+    return {
+      key: "provider:" + entry.backendId,
+      backendId: entry.backendId,
+      label: entry.label,
+      detail: hidden ? "Hidden" : (entry.connected ? "Connected" : "Shown"),
+      glyph: entry.glyph,
+      hidden: hidden
+    }
+  })
+  readonly property var rows: providersOpen ? providerRows : (backend ? backend.targets : [])
   // Tool settings, for the backends that have any. A backend without them
   // simply has no block here.
   readonly property var toggles: backend && backend.toggles ? backend.toggles : []
-  readonly property bool settingsAvailable: toggles.length > 0
+  readonly property bool settingsAvailable: !providersOpen && toggles.length > 0
   readonly property bool settingsVisible: settingsAvailable && settingsExpanded
-  readonly property bool switcherVisible: vpn.availableBackends.length > 1
-  readonly property bool filterVisible: backend !== null && backend.supportsFilter
+  readonly property bool switcherVisible: !providersOpen && vpn.availableBackends.length > 1
+  readonly property bool filterVisible: !providersOpen && backend !== null && backend.supportsFilter
+  readonly property bool masterSwitchVisible: backend !== null
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
+  readonly property bool gearHasCursor: headerHasCursor && headerIndex === 0
+  readonly property bool switchHasCursor: headerHasCursor && headerIndex === 1
   readonly property string statusLine: {
-    if (!backend) return "Install Proton VPN, Mullvad, OpenVPN, or WireGuard to use this widget."
+    if (providersOpen) return ""
+    if (!backend) {
+      if (vpn.detectedBackends.length > 0) return "Every VPN tool is hidden. Turn one back on with the gear."
+      return vpn.setupHint !== ""
+        ? vpn.setupHint
+        : "Install Proton VPN, Mullvad, OpenVPN, or WireGuard to use this widget."
+    }
     return backend.actionStatus !== "" ? backend.actionStatus : backend.lastError
   }
 
@@ -47,6 +75,13 @@ Panel {
     if (rows.length === 0 && focusSection === "rows") focusSection = "header"
     if (!settingsAvailable && focusSection === "hero") focusSection = "header"
     if (!settingsVisible && focusSection === "toggles") focusSection = settingsAvailable ? "hero" : "header"
+    if (!switcherVisible && focusSection === "switcher") focusSection = "header"
+    // The master switch is gone without a backend, so the gear is all the
+    // header has left — and it is the way back from a widget with everything
+    // hidden, which is exactly when that happens.
+    if (!masterSwitchVisible) headerIndex = 0
+    if (headerIndex < 0) headerIndex = 0
+    if (headerIndex > 1) headerIndex = 1
     if (rowIndex >= rows.length) rowIndex = Math.max(0, rows.length - 1)
     if (rowIndex < 0) rowIndex = 0
     if (toggleIndex >= toggles.length) toggleIndex = Math.max(0, toggles.length - 1)
@@ -59,6 +94,7 @@ Panel {
 
     if (dx !== 0) {
       if (focusSection === "switcher") stepBackend(dx)
+      else if (focusSection === "header") stepHeader(dx)
       return
     }
     if (dy === 0) return
@@ -134,10 +170,17 @@ Panel {
     if (panelFlick) panelFlick.contentY = 0
   }
 
-  function setHeaderCursor() {
+  function setHeaderCursor(index) {
     cursorActive = true
     focusSection = "header"
+    if (index !== undefined) headerIndex = index
+    if (!masterSwitchVisible) headerIndex = 0
     if (panelFlick) panelFlick.contentY = 0
+  }
+
+  function stepHeader(direction) {
+    if (!masterSwitchVisible) return
+    headerIndex = Math.max(0, Math.min(1, headerIndex + direction))
   }
 
   function setRowCursor(index) {
@@ -174,13 +217,52 @@ Panel {
     else if (settingsExpanded) setHeroCursor()
   }
 
+  // The gear and the provider rows work without a backend — they are how you
+  // get one back — so they are checked before the "nothing detected" bail.
   function activateCursor() {
     ensureCursor()
+    if (focusSection === "header") {
+      if (headerIndex === 0) toggleProviders()
+      else if (backend) vpn.toggleActive()
+      return
+    }
+    if (focusSection === "rows" && rows.length > 0) {
+      activateRow(rows[rowIndex])
+      return
+    }
     if (!backend) return
-    if (focusSection === "header") vpn.toggleActive()
-    else if (focusSection === "hero") toggleSettings()
+    if (focusSection === "hero") toggleSettings()
     else if (focusSection === "toggles" && toggles.length > 0) flipToggle(toggleIndex)
-    else if (focusSection === "rows" && rows.length > 0) activateRow(rows[rowIndex])
+  }
+
+  // A view, not a drawer: the cursor stays on the gear that opened it, which is
+  // also the way out.
+  function toggleProviders() {
+    providersOpen = !providersOpen
+    rowIndex = 0
+    toggleIndex = 0
+    filterField.text = ""
+    setHeaderCursor(0)
+  }
+
+  function toggleProvider(row) {
+    if (!row || row.backendId === undefined) return
+    var next = Model.toggleBackendId(vpn.hiddenBackendIds, row.backendId)
+    saveSetting("hiddenBackends", Model.joinBackendIds(next))
+  }
+
+  // Widget settings live in this widget's shell.json entry, the same place the
+  // Omarchy settings dialog writes them, so the two agree on the next reload.
+  function saveSetting(key, value) {
+    var next = {}
+    for (var name in settings) {
+      if (name !== "id") next[name] = settings[name]
+    }
+    next[key] = value
+    root.settings = next
+    if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
+      bar.shell.updateEntryInline(root.moduleName, next)
+    }
   }
 
   // Settings go straight to the backend: they change how the tool behaves, not
@@ -199,7 +281,12 @@ Panel {
   }
 
   function activateRow(row) {
-    if (!backend || !row) return
+    if (!row) return
+    if (providersOpen) {
+      toggleProvider(row)
+      return
+    }
+    if (!backend) return
     // Through the controller, never straight to the backend: picking a tunnel
     // means the others come down first.
     vpn.connectVia(backend, row)
@@ -240,6 +327,10 @@ Panel {
     cursorActive = false
     rowIndex = 0
     toggleIndex = 0
+    headerIndex = 1
+    // The tool settings stay however you left them; this view does not. You
+    // open the panel to connect, not to reconsider which tools exist.
+    providersOpen = false
     focusSection = "rows"
     filterField.text = ""
     if (panelFlick) panelFlick.contentY = 0
@@ -385,20 +476,23 @@ Panel {
           spacing: Style.space(12)
 
           // Status bar for the whole widget: where traffic is coming out on the
-          // left, the one master switch on the right. Both sit above the
-          // backend chips because they describe the connection, not the tool.
+          // left, the gear and the one master switch on the right. All of it
+          // sits above the backend chips because it describes the connection
+          // and the widget, not whichever tool is being looked at.
           Item {
             id: header
             width: parent.width
-            implicitHeight: Math.max(ipLabel.implicitHeight, masterSwitch.implicitHeight)
-            readonly property bool ringVisible: root.headerHasCursor
-            function focusHeader() { root.setHeaderCursor() }
+            implicitHeight: Math.max(ipLabel.implicitHeight,
+              Math.max(gearButton.implicitHeight, masterSwitch.implicitHeight))
+            readonly property real controlsWidth: gearButton.width
+              + (masterSwitch.visible ? masterSwitch.width + Style.space(8) : 0)
+              + Style.space(12)
 
             Item {
               id: ipLabel
               anchors.left: parent.left
               anchors.verticalCenter: parent.verticalCenter
-              width: Math.min(ipRow.implicitWidth, parent.width - masterSwitch.width - Style.space(12))
+              width: Math.min(ipRow.implicitWidth, parent.width - header.controlsWidth)
               height: ipRow.implicitHeight
 
               // Only an address is worth copying; a placeholder is not.
@@ -443,16 +537,30 @@ Panel {
               }
             }
 
+            PanelActionButton {
+              id: gearButton
+              anchors.right: masterSwitch.visible ? masterSwitch.left : parent.right
+              anchors.rightMargin: masterSwitch.visible ? Style.space(8) : 0
+              anchors.verticalCenter: parent.verticalCenter
+              iconText: Model.GLYPH_COG
+              tooltipText: root.providersOpen ? "Back" : "Widget settings"
+              hasCursor: root.gearHasCursor
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              onHovered: function(on) { if (on) root.setHeaderCursor(0) }
+              onClicked: root.toggleProviders()
+            }
+
             ToggleSwitch {
               id: masterSwitch
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
-              visible: root.backend !== null
+              visible: root.masterSwitchVisible
               checked: vpn.anyConnected
               busy: root.backend ? root.backend.busy : false
-              hasCursor: header.ringVisible
+              hasCursor: root.switchHasCursor
               foreground: root.foreground
-              onHovered: function(on) { if (on) header.focusHeader() }
+              onHovered: function(on) { if (on) root.setHeaderCursor(1) }
               onToggled: vpn.toggleActive()
 
               PanelToolTip {
@@ -486,6 +594,7 @@ Panel {
           // the hero exactly as it was.
           CursorSurface {
             id: heroSurface
+            visible: !root.providersOpen
             width: parent.width
             implicitHeight: hero.implicitHeight + Style.spacing.rowPaddingX
             hasCursor: root.cursorActive && root.focusSection === "hero"
@@ -549,7 +658,7 @@ Panel {
           }
 
           Column {
-            visible: root.backend !== null && root.backend.details.length > 0
+            visible: !root.providersOpen && root.backend !== null && root.backend.details.length > 0
             width: parent.width
             spacing: Style.spacing.labelGap
 
@@ -589,7 +698,7 @@ Panel {
           }
 
           PanelSeparator {
-            visible: root.backend !== null
+            visible: root.providersOpen || root.backend !== null
             foreground: root.foreground
           }
 
@@ -615,12 +724,15 @@ Panel {
           }
 
           Column {
-            visible: root.backend !== null
+            visible: root.providersOpen || root.backend !== null
             width: parent.width
             spacing: Style.space(10)
 
             PanelSectionHeader {
-              text: root.filterVisible && root.backend && root.backend.filter !== "" ? "MATCHING" : "CONNECT"
+              text: {
+                if (root.providersOpen) return "PROVIDERS"
+                return root.filterVisible && root.backend && root.backend.filter !== "" ? "MATCHING" : "CONNECT"
+              }
               foreground: root.foreground
               fontFamily: root.fontFamily
             }
@@ -628,7 +740,10 @@ Panel {
             Text {
               visible: root.rows.length === 0
               width: parent.width
-              text: root.backend ? root.backend.emptyText : ""
+              text: {
+                if (root.providersOpen) return "No VPN tool detected on this machine."
+                return root.backend ? root.backend.emptyText : ""
+              }
               color: root.dim
               font.family: root.fontFamily
               font.pixelSize: Style.font.bodySmall
@@ -662,7 +777,13 @@ Panel {
     id: targetRow
     property var row: null
     property int cursorIndex: 0
-    readonly property bool isCurrent: root.backend !== null
+    // A provider row is the same row with a switch where the check mark goes:
+    // it says whether the widget uses that tool, not whether it is connected.
+    readonly property bool isProvider: row !== null && row.hidden !== undefined
+    // A hidden tool reads as switched off rather than as a row you could pick.
+    readonly property bool rowMuted: isProvider && row.hidden === true
+    readonly property bool isCurrent: !isProvider
+      && root.backend !== null
       && row
       && row.key === root.backend.currentKey
 
@@ -690,7 +811,7 @@ Panel {
 
       Text {
         text: targetRow.row ? targetRow.row.glyph : ""
-        color: root.foreground
+        color: targetRow.rowMuted ? root.dim : root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.icon
         Layout.alignment: Qt.AlignVCenter
@@ -704,7 +825,7 @@ Panel {
         Text {
           Layout.fillWidth: true
           text: targetRow.row ? targetRow.row.label : ""
-          color: root.foreground
+          color: targetRow.rowMuted ? root.dim : root.foreground
           font.family: root.fontFamily
           font.pixelSize: Style.font.body
           elide: Text.ElideRight
@@ -727,6 +848,17 @@ Panel {
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.icon
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ToggleSwitch {
+        visible: targetRow.isProvider
+        checked: targetRow.isProvider && !targetRow.row.hidden
+        foreground: root.foreground
+        // Same reason the tool settings do it: the row owns the click and the
+        // cursor ring, so a switch that owned them too would read as a second
+        // target inside the first.
+        interactive: false
         Layout.alignment: Qt.AlignVCenter
       }
     }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ actually have installed.
 
 It supports **Proton VPN**, **Mullvad**, and the **OpenVPN** and **WireGuard**
 profiles NetworkManager holds. Only the tools
-found on your machine appear — install none and the widget tells you so; install
-several and a chip row lets you switch between them.
+that have something to offer appear — install none and the widget tells you so;
+have several and a chip row lets you switch between them.
 
 <img src="preview.png" alt="The VPN panel open in the Omarchy bar, showing a Proton VPN connection to Zurich and a country list" width="365">
 
@@ -49,6 +49,11 @@ Inside the panel:
 - **The switch** top-right connects or disconnects. Turning one VPN on shuts
   every other one off first — you never end up with two tunnels fighting over
   your routes.
+- **The gear** to its left opens the widget's own settings, which for now is one
+  switch per tool found on this machine. Turn one off and the widget forgets it
+  entirely: no chip, no polling, and it stops counting toward the bar icon. Turn
+  it back on from the same place. The choice is written to
+  `~/.config/omarchy/shell.json` and survives a restart.
 - **The chips** below choose which tool you are looking at. They only appear
   when you have more than one installed.
 - **The name row** is also a drawer. Tools with settings of their own get a
@@ -68,8 +73,9 @@ Inside the panel:
 Keyboard, once the panel is open: `j`/`k` or arrows move — through the header,
 the chips, the name row, the settings switches if they are open, then the list —
 `Enter` connects, flips a switch, or opens and closes the settings drawer,
-depending on what the cursor is on. `h`/`l` move along the chip row, `s` cycles
-tools, `/` searches countries, `d` disconnects, `r` refreshes, `Esc` closes.
+depending on what the cursor is on. `h`/`l` move along the chip row and between
+the gear and the master switch in the header, `s` cycles tools, `/` searches
+countries, `d` disconnects, `r` refreshes, `Esc` closes.
 
 The public IP is fetched from `checkip.amazonaws.com` — never on a timer, only
 when the connection changes, when the panel first opens, or when you ask.
@@ -94,6 +100,7 @@ Configure these in **Setup › Plugins**, or in the widget's entry in
 | `refreshIntervalSec` | `15` | How often the connection status is polled |
 | `preferredBackend` | `Auto` | Which tool the panel opens on. `Auto` picks whichever is connected |
 | `favoriteCountries` | `CH,NL,US` | Country codes pinned to the top of the Proton VPN and Mullvad lists |
+| `hiddenBackends` | *(empty)* | Tools the widget ignores entirely: `proton`, `mullvad`, `networkmanager`. The gear inside the panel writes this |
 
 ## Mullvad
 
@@ -130,6 +137,11 @@ They share one chip, and the row icon says which is which. Import one with:
 nmcli connection import type openvpn file ~/Downloads/office.ovpn
 nmcli connection import type wireguard file ~/Downloads/home.conf
 ```
+
+NetworkManager runs on every desktop, so the chip appears only once you have a
+profile it can actually carry — an OpenVPN one with `openvpn` installed, or a
+WireGuard one with `wireguard-tools`. Until then the panel shows the import
+command above rather than a chip leading to an empty list.
 
 A tunnel you started some other way is not listed: a bare `openvpn` process,
 `openvpn-client@.service`, or a `wg-quick@` unit. Neither is a tunnel another

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -10,7 +10,8 @@ import "Model.js" as Model
 //   backendId, label, glyph          identity for the switcher chips
 //   supportsFilter, filterPlaceholder whether the panel shows its filter field
 //   filter                           panel writes the current filter text here
-//   detected                         tool is installed and usable
+//   detected                         tool is installed and has something to offer
+//   setupHint                        optional: what to do about being undetected
 //   connected, summary               headline state
 //   details                          [{ label, value }] shown while connected
 //   targets                          [{ key, label, detail, glyph, args }]
@@ -30,8 +31,19 @@ Item {
   property string selectedId: ""
 
   readonly property var backends: [proton, mullvad, networkManager]
-  readonly property var availableBackends: backends.filter(function(backend) { return backend.detected })
+  // Tools this machine has. Hiding one is a statement about the widget, not
+  // about the machine, so the settings view lists these — including the hidden
+  // ones, which would otherwise be unreachable once they were switched off.
+  readonly property var detectedBackends: backends.filter(function(backend) { return backend.detected })
+  readonly property var hiddenBackendIds: Model.parseBackendIds(setting("hiddenBackends", ""))
+  readonly property var availableBackends: detectedBackends.filter(function(backend) {
+    return !root.isHidden(backend.backendId)
+  })
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 15, 5, 600)
+
+  function isHidden(backendId) {
+    return hiddenBackendIds.indexOf(String(backendId)) !== -1
+  }
 
   readonly property var active: {
     var available = availableBackends
@@ -68,7 +80,9 @@ Item {
   }
 
   readonly property string barSummary: {
-    if (!anyDetected) return "No VPN tool installed"
+    if (!anyDetected) {
+      return detectedBackends.length > 0 ? "Every VPN tool is hidden" : "No VPN tool installed"
+    }
     var backend = connectedBackend
     if (!backend) return "Not connected"
     return backend.label + " · " + backend.summary
@@ -77,6 +91,18 @@ Item {
   readonly property var switcherOptions: availableBackends.map(function(backend) {
     return { value: backend.backendId, label: backend.label }
   })
+
+  // An installed tool with nothing to show hides itself, so the panel would
+  // otherwise tell you to install what you already have. Optional: a backend
+  // without the property simply has nothing to say.
+  readonly property string setupHint: {
+    for (var i = 0; i < backends.length; i++) {
+      if (isHidden(backends[i].backendId)) continue
+      var hint = backends[i].setupHint
+      if (hint !== undefined && String(hint) !== "") return String(hint)
+    }
+    return ""
+  }
 
   // ------------------------------------------------------------- public IP
 
@@ -231,10 +257,12 @@ Item {
     }
   }
 
+  // A hidden tool is still probed — the settings view has to list it for you to
+  // switch it back on — but never polled: not asking is the point of hiding it.
   function refreshAll() {
     for (var i = 0; i < backends.length; i++) {
-      if (backends[i].detected) backends[i].refresh()
-      else backends[i].detect()
+      if (!backends[i].detected) backends[i].detect()
+      else if (!isHidden(backends[i].backendId)) backends[i].refresh()
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
     "defaults": {
       "refreshIntervalSec": 15,
       "preferredBackend": "Auto",
-      "favoriteCountries": "CH,NL,US"
+      "favoriteCountries": "CH,NL,US",
+      "hiddenBackends": ""
     },
     "schema": [
       {
@@ -46,6 +47,13 @@
         "type": "string",
         "label": "Favorite countries (comma separated)",
         "defaultValue": "CH,NL,US"
+      },
+      {
+        "key": "hiddenBackends",
+        "type": "string",
+        "label": "Hidden VPN tools (comma separated)",
+        "defaultValue": "",
+        "description": "Tools the widget ignores entirely: proton, mullvad, networkmanager. Also editable from the gear inside the panel."
       }
     ]
   }


### PR DESCRIPTION
Two changes, both about the panel showing less of what you cannot act on.

## Hide NetworkManager when it has no eligible profile (closes #6)

NetworkManager ships on every desktop, so `nmcli` being present said nothing about whether this machine has a tunnel to offer. An install with no importable profile still got a chip, a hero, and an empty CONNECT list.

- `detected` is now `_toolsPresent && profiles.length > 0`.
- Eligibility also checks kind against the installed tool: OpenVPN profiles are dropped without `openvpn`, WireGuard ones without `wg`. NetworkManager lists profiles nothing can run.
- `detect()` stays callable every poll, since the controller keeps calling it while the backend is undetected. The binary probes run once; after that `detect()` is a plain `refresh()`. `refresh()` gates on tool presence rather than `detected`, so an import can bring the backend back.
- Hiding it would have buried the import instructions, so backends may now expose an optional `setupHint`. The panel shows the first non-empty one in place of "Install Proton VPN, Mullvad, OpenVPN, or WireGuard…", which is the wrong advice for someone who has the tools and only lacks a profile.

The issue's other bullet — chips hidden when there is only one option — was already the behaviour (`switcherVisible: vpn.availableBackends.length > 1`). What made the chip row look redundant was NetworkManager appearing with nothing behind it.

## A widget settings view behind a gear

A gear sits in the header, left of the master switch. It swaps the panel body for a `PROVIDERS` list: one row per tool found on this machine, switch on the right, hidden rows dimmed.

- Hiding drops the tool from `availableBackends` entirely: no chip, no polling, no weight in the bar icon or tooltip, and exclusivity never tears it down. It is still probed, so the settings view can list it for you to switch it back on.
- A view, not a drawer — nothing in the connect list means anything while you are choosing which tools the widget should know about. It resets when the panel closes, unlike the tool-settings drawer.
- The gear and the provider rows work with no backend at all. That is the way out of "everything hidden", where the master switch is gone and the header cursor pins to the gear.
- Persisted as `hiddenBackends`, a comma-separated id list, through `bar.shell.updateEntryInline` into this widget's `shell.json` entry — the same entry Setup › Plugins writes — and declared in `manifest.json` so both sides agree. `settings` holds only inline overrides, so writing it back cannot bake today's defaults into the config.
- Keyboard: `h`/`l` move between the gear and the master switch; `Enter` opens the view or flips the row under the cursor.

## Verification

`qmllint` clean. Both changes exercised against the real `Panel.qml` loaded in a throwaway `quickshell` instance, with `omarchy-cmd-present` and `nmcli` stubbed to fake each machine shape:

| state | chips | result |
|---|---|---|
| all three tools, 3 profiles | proton, mullvad, networkmanager | unchanged from today |
| NM tools installed, no VPN connections | proton, mullvad | NetworkManager gone |
| NM tools only, no profiles | none | "No profiles yet. Import one with: nmcli …" |
| nothing installed | none | "Install Proton VPN, Mullvad, …" |
| `openvpn` absent, `wg` present | NM kept | OpenVPN profiles dropped, probes ran once |
| hide Proton, then Mullvad | — | active backend falls through, then master switch disappears and the cursor pins to the gear |
| unhide | — | backend returns, setting round-trips |

🤖 Generated with [Claude Code](https://claude.com/claude-code)