### PR TITLE
fix: stop the panel vouching for protection it never verified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  model:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # No install step: the suite is stdlib-only on purpose, so it runs the
+      # same way here as it does on a machine with the plugin checked out.
+      - run: node tests/run.js

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,10 @@ the switch flip the instant it is clicked instead of waiting a poll cycle.
 Reality reasserts itself once the tool agrees, or after the settle timer gives
 up.
 
-**Public IP.** Fetched with `curl checkip.amazonaws.com`, never polled. The
+**Public IP.** Fetched with `curl https://checkip.amazonaws.com`, never polled.
+The scheme is explicit — over plain HTTP anyone on the path could forge the
+address the panel presents as proof the tunnel works — and the response is only
+believed if it parses as an address literal. The
 trigger is `connectionKey` — a string built from the connected backend's id and
 summary — so a connect, a disconnect, or a server switch all invalidate it. A
 2s delay lets routes settle first, since asking too early returns the old
@@ -244,3 +247,24 @@ registered for target …` appears once per extra monitor. Every first-party
 widget logs the same thing; it is not a defect.
 
 Check a manifest change with `omarchy plugin validate .` before committing.
+
+## Tests
+
+`Model.js` is where every assumption about how three CLIs format their output
+lives, and it is the one file that runs without a QML engine. The suite covers
+it:
+
+```bash
+node tests/run.js
+qmllint *.qml          # one file per invocation; a batch exits 255 regardless
+```
+
+No framework and no `package.json` — a suite that needed installing would not
+get run, and the plugin is not built. `tests/run.js` evaluates `Model.js` in the
+node realm and collects the names it declares, since a `.pragma library` has no
+exports. CI runs the same command on push and pull request.
+
+The QML halves are not covered: they are `Process` plumbing and bindings, and
+the interesting logic was pushed into `Model.js` precisely so it could be
+tested. When a bug turns out to live in a parser, the fix belongs there with a
+case beside it.

--- a/Model.js
+++ b/Model.js
@@ -15,6 +15,33 @@ var GLYPH_COG = String.fromCodePoint(0xF0493)
 
 // ----------------------------------------------------------------- shared
 
+// The exit address lookup answers with a bare address and nothing else. A
+// captive portal's login page, a proxy's error body, or anything else that
+// came back with it is not an answer — and this is the one number a user reads
+// to decide whether the tunnel is carrying their traffic, so rendering
+// whatever arrived would be the widget confirming a route it never saw.
+// Returns "" for anything that is not an address literal.
+function parsePublicIp(raw) {
+  var text = String(raw || "").trim()
+  // Longest possible IPv6 text form; anything longer is not an address.
+  if (text === "" || text.length > 45) return ""
+
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(text)) {
+    var octets = text.split(".")
+    for (var i = 0; i < octets.length; i++) {
+      if (parseInt(octets[i], 10) > 255) return ""
+    }
+    return text
+  }
+
+  // IPv6 has too many legal spellings to re-implement here, so this checks the
+  // alphabet and the shape rather than the grouping.
+  if (/^[0-9a-fA-F:]+$/.test(text) && text.indexOf("::") === text.lastIndexOf("::")) {
+    if (text.indexOf(":") !== -1 && !/:::/.test(text)) return text.toLowerCase()
+  }
+  return ""
+}
+
 function elide(text, limit) {
   var value = String(text || "").replace(/\s+/g, " ").trim()
   return value.length > limit ? value.substring(0, limit - 1) + "…" : value
@@ -351,9 +378,10 @@ function unescapeNmcli(value) {
 }
 
 // Generated on the fly for a device someone else brought up, rather than a
-// profile on disk. An older nmcli that does not report FILENAME leaves this
-// empty, in which case the connection is kept — better a stray row than a
-// backend that lists nothing at all.
+// profile on disk. Empty means the field was never asked for: nmcli refuses a
+// listing that names a field it does not know, so an nmcli too old for
+// FILENAME is retried without it — see NetworkManagerBackend. Such a
+// connection is kept, since a stray row beats a backend that lists nothing.
 function isVolatileConnection(filename) {
   return String(filename || "").indexOf("/run/") === 0
 }
@@ -745,8 +773,14 @@ function mullvadCurrentKey(status, countries) {
 //   Autoconnect: off
 //   Block traffic when the VPN is disconnected: off
 //   Local network sharing setting: block
+//
+// One shell means one exit code — the last subcommand's — so a subcommand that
+// failed or that this version of the CLI does not have leaves no line and no
+// error. `seen` is which answers actually arrived: an unanswered setting is
+// unknown, not off. Reporting lockdown mode as off while it is on is the one
+// mistake a VPN widget must not make.
 function parseMullvadSettings(raw) {
-  var settings = { autoconnect: false, lockdown: false, lan: false, loaded: false }
+  var settings = { autoconnect: false, lockdown: false, lan: false, seen: {}, loaded: false }
   var lines = String(raw || "").split("\n")
 
   for (var i = 0; i < lines.length; i++) {
@@ -760,26 +794,39 @@ function parseMullvadSettings(raw) {
 
     if (key === "autoconnect") {
       settings.autoconnect = value === "on"
-      settings.loaded = true
+      settings.seen.autoconnect = true
     } else if (key.indexOf("block traffic") === 0) {
       settings.lockdown = value === "on"
-      settings.loaded = true
+      settings.seen.lockdown = true
     } else if (key.indexOf("local network sharing") === 0) {
       settings.lan = value === "allow"
-      settings.loaded = true
+      settings.seen.lan = true
     }
   }
+
+  settings.loaded = settings.seen.autoconnect === true
+    || settings.seen.lockdown === true
+    || settings.seen.lan === true
   return settings
 }
 
+// A switch is drawn only for a setting the daemon answered for. A partial read
+// shows fewer switches rather than a full row of confident wrong ones.
 function mullvadToggles(settings) {
   if (!settings || !settings.loaded) return []
 
-  return [
-    toggle("autoconnect", "Connect on startup", "Up as soon as the daemon starts", settings.autoconnect),
-    toggle("lockdown", "Lockdown mode", "No traffic at all while down", settings.lockdown),
-    toggle("lan", "Allow local network", "Reach printers and NAS while up", settings.lan)
-  ]
+  var seen = settings.seen || {}
+  var toggles = []
+  if (seen.autoconnect === true) {
+    toggles.push(toggle("autoconnect", "Connect on startup", "Up as soon as the daemon starts", settings.autoconnect))
+  }
+  if (seen.lockdown === true) {
+    toggles.push(toggle("lockdown", "Lockdown mode", "No traffic at all while down", settings.lockdown))
+  }
+  if (seen.lan === true) {
+    toggles.push(toggle("lan", "Allow local network", "Reach printers and NAS while up", settings.lan))
+  }
+  return toggles
 }
 
 function mullvadToggleArgs(key, value) {

--- a/MullvadBackend.qml
+++ b/MullvadBackend.qml
@@ -30,8 +30,12 @@ Item {
   property string lastError: ""
 
   // The stored "block traffic while disconnected" setting, which the status
-  // payload only reports while the tunnel is already down.
-  readonly property bool lockdownMode: daemonSettings.lockdown
+  // payload only reports while the tunnel is already down. False also covers
+  // "the daemon never answered for it" — see parseMullvadSettings — so this
+  // drives a warning and never a switch position.
+  readonly property bool lockdownMode: daemonSettings.seen !== undefined
+    && daemonSettings.seen.lockdown === true
+    && daemonSettings.lockdown
 
   // Switches the panel draws under the detail rows. Values are whatever the
   // daemon last reported; the widget stores none of them.
@@ -67,8 +71,13 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
-  function detect() {
+  // Asked once. `force` is the user asking again, which is the only time the
+  // answer could have changed — see refreshAll() in VpnController.
+  property bool _probed: false
+
+  function detect(force) {
     if (detectProcess.running) return
+    if (_probed && force !== true) return
     detectProcess.running = true
   }
 
@@ -94,18 +103,23 @@ Item {
     _toggleKey = key
     toggleProcess.command = ["mullvad"].concat(args)
     toggleProcess.running = true
+    pendingTimer.restart()
   }
 
   function applySettings(raw) {
     var parsed = Model.parseMullvadSettings(raw)
+    // A read that answered nothing is not a report that everything is off.
+    // Keep whatever the daemon last actually said.
+    if (!parsed.loaded) return
     root.daemonSettings = parsed
 
     // Drop the optimistic value only for the switches the daemon now agrees
-    // with, so a poll landing mid-flight cannot flick the others back.
+    // with, so a poll landing mid-flight cannot flick the others back. A
+    // setting the daemon did not answer for agrees with nothing.
     var pending = {}
     var changed = false
     for (var key in _pendingToggles) {
-      if (parsed[key] === _pendingToggles[key]) changed = true
+      if (parsed.seen[key] === true && parsed[key] === _pendingToggles[key]) changed = true
       else pending[key] = _pendingToggles[key]
     }
     if (changed) _pendingToggles = pending
@@ -187,6 +201,22 @@ Item {
     return "The Mullvad daemon is not responding. Start it with: sudo systemctl start mullvad-daemon"
   }
 
+  // A command that exits clean but does not take — the daemon accepts it and
+  // then reports the old value — would otherwise leave the switch showing the
+  // position the user asked for, marked busy, for as long as the panel is open.
+  // Optimism gets a deadline: past it, the switches go back to what the daemon
+  // actually says, which is the whole point of not storing them here.
+  Timer {
+    id: pendingTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (Object.keys(root._pendingToggles).length === 0) return
+      root._pendingToggles = ({})
+      root.lastError = "Mullvad did not apply that setting."
+    }
+  }
+
   // The daemon reports the new state a beat after the command returns, and a
   // WireGuard handshake over a slow link can take a few seconds more than
   // Proton's CLI does, so poll a little longer than that backend.
@@ -228,6 +258,7 @@ Item {
     command: ["omarchy-cmd-present", "mullvad"]
     running: true
     onExited: function(exitCode) {
+      root._probed = true
       root.detected = exitCode === 0
       if (root.detected) root.refresh()
     }
@@ -257,13 +288,16 @@ Item {
 
   // Three subcommands, one process. Each answer names itself, so the parser
   // does not care about the order they come back in.
+  //
+  // The exit code belongs to the last subcommand alone and says nothing about
+  // the other two, so it is not consulted: the parser reads whichever answers
+  // arrived and reports the rest as unanswered rather than as off.
   Process {
     id: settingsProcess
     running: false
     command: ["bash", "-c", "mullvad auto-connect get; mullvad lockdown-mode get; mullvad lan get"]
     stdout: StdioCollector { id: settingsStdout; waitForEnd: true }
     onExited: function(exitCode) {
-      if (exitCode !== 0) return
       root.applySettings(String(settingsStdout.text || ""))
     }
   }
@@ -286,6 +320,10 @@ Item {
     }
   }
 
+  // `relay list` is the largest thing this CLI prints, so "loaded" has to mean
+  // "asked and answered", not "answered with something". Keying it off the
+  // parsed count made a format change re-fetch the whole list on every poll,
+  // forever, while the panel showed no countries and no reason why.
   Process {
     id: relaysProcess
     running: false
@@ -294,7 +332,10 @@ Item {
     onExited: function(exitCode) {
       if (exitCode !== 0) return
       root.relays = Model.parseMullvadRelays(String(relaysStdout.text || ""))
-      root.relaysLoaded = root.relays.length > 0
+      root.relaysLoaded = true
+      if (root.relays.length === 0) {
+        root.lastError = "Could not read the relay list. Check: mullvad relay list"
+      }
     }
   }
 

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -74,12 +74,13 @@ Item {
   // detect() on a machine that has the tools and no profiles. The binaries do
   // not come and go; once probed, this is a plain refresh rather than three
   // more processes every poll.
-  function detect() {
-    if (_probed) {
+  function detect(force) {
+    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
+    if (_probed && force !== true) {
       refresh()
       return
     }
-    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
+    _probesDone = 0
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
@@ -92,8 +93,11 @@ Item {
     if (root._toolsPresent) root.refresh()
   }
 
+  // The two passes share `listProcess.pending`, so a refresh landing while the
+  // second one is still out would hand it a list the details it is holding do
+  // not describe. One discovery at a time.
   function refresh() {
-    if (!_toolsPresent || listProcess.running) return
+    if (!_toolsPresent || listProcess.running || typesProcess.running) return
     listProcess.running = true
   }
 
@@ -254,19 +258,48 @@ Item {
     }
   }
 
+  // nmcli rejects the whole call when asked for a field it does not know, so an
+  // nmcli too old for FILENAME does not return rows without it — it returns
+  // nothing at all, and the backend would silently never appear. The first
+  // refusal drops the field and the list is fetched again; volatile-connection
+  // filtering is what is lost, which is a stray row rather than no backend.
+  property bool _filenameField: true
+  readonly property var _listCommand: _filenameField
+    ? ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE,FILENAME", "connection", "show"]
+    : ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE", "connection", "show"]
+
+  function unknownField(text) {
+    return /not among|unknown field|invalid field|allowed fields/i.test(String(text || ""))
+  }
+
+  // Retrying from inside onExited would re-enter the process that is still
+  // finishing, the same reason the connect chain hops through the event loop.
+  Timer {
+    id: listRetry
+    interval: 0
+    repeat: false
+    onTriggered: root.refresh()
+  }
+
   // Every tunnel-shaped connection: `vpn` whichever plugin backs it, plus
   // `wireguard`, which NetworkManager types as its own thing rather than as a
   // VPN plugin.
   Process {
     id: listProcess
     running: false
-    command: ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE,FILENAME", "connection", "show"]
+    command: root._listCommand
     stdout: StdioCollector { id: listStdout; waitForEnd: true }
     stderr: StdioCollector { id: listStderr; waitForEnd: true }
     property var pending: []
     onExited: function(exitCode) {
       if (exitCode !== 0) {
-        root.lastError = Model.elide(String(listStderr.text || "") || "Could not list NetworkManager connections", 140)
+        var failure = String(listStderr.text || "")
+        if (root._filenameField && root.unknownField(failure)) {
+          root._filenameField = false
+          listRetry.restart()
+          return
+        }
+        root.lastError = Model.elide(failure || "Could not list NetworkManager connections", 140)
         return
       }
 
@@ -304,9 +337,16 @@ Item {
     running: false
     command: []
     stdout: StdioCollector { id: typesStdout; waitForEnd: true }
+    stderr: StdioCollector { id: typesStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      // One profile deleted between the two passes fails the whole call. That
+      // is a reason to keep the list from last time, not to declare the machine
+      // has no tunnels: emptying it here drops `detected`, takes the chip away
+      // while a tunnel is up, and with it the only way to bring that tunnel
+      // down — disconnect() refuses to run undetected.
       if (exitCode !== 0) {
-        root.applyProfiles([])
+        root.lastError = Model.elide(
+          String(typesStderr.text || "") || "Could not read NetworkManager profile details", 140)
         return
       }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -60,8 +60,14 @@ Panel {
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
   readonly property bool gearHasCursor: headerHasCursor && headerIndex === 0
   readonly property bool switchHasCursor: headerHasCursor && headerIndex === 1
+  // The controller's notice outranks the backend's own line: it says why the
+  // connect now under way cannot land, which is worth more than watching it
+  // report that it is under way.
+  readonly property bool statusIsError: vpn.notice !== ""
+    || (backend !== null && backend.lastError !== "" && backend.actionStatus === "")
   readonly property string statusLine: {
     if (providersOpen) return ""
+    if (vpn.notice !== "") return vpn.notice
     if (!backend) {
       if (vpn.detectedBackends.length > 0) return "Every VPN tool is hidden. Turn one back on with the gear."
       return vpn.setupHint !== ""
@@ -157,7 +163,13 @@ Panel {
     selectBackend(options[next].backendId)
   }
 
+  // The filter field belongs to the panel, not to the tool, so it does not
+  // travel with the chip. Both ends are cleared on the way across: the outgoing
+  // tool would otherwise keep a filter nothing is showing, and the field would
+  // sit there full of text the incoming list is not filtered by.
   function selectBackend(backendId) {
+    if (root.backend) root.backend.filter = ""
+    filterField.text = ""
     vpn.selectBackend(backendId)
     rowIndex = 0
     toggleIndex = 0
@@ -241,6 +253,7 @@ Panel {
     providersOpen = !providersOpen
     rowIndex = 0
     toggleIndex = 0
+    if (backend) backend.filter = ""
     filterField.text = ""
     setHeaderCursor(0)
   }
@@ -332,9 +345,12 @@ Panel {
     // open the panel to connect, not to reconsider which tools exist.
     providersOpen = false
     focusSection = "rows"
+    if (backend) backend.filter = ""
     filterField.text = ""
     if (panelFlick) panelFlick.contentY = 0
-    vpn.refreshAll()
+    // Opening the panel re-probes for tools installed since the shell started;
+    // the background poll deliberately does not.
+    vpn.refreshAll(true)
     // The address is fetched on connection changes, not on a timer, so a first
     // open with nothing cached is the one other moment worth asking.
     if (vpn.publicIp === "") vpn.refreshPublicIp()
@@ -373,7 +389,7 @@ Panel {
     function show(): void { root.open() }
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
-    function refresh(): string { vpn.refreshAll(); vpn.refreshPublicIp(); return "ok" }
+    function refresh(): string { vpn.refreshAll(true); vpn.refreshPublicIp(); return "ok" }
     function status(): string { return vpn.barSummary }
     function ip(): string { return vpn.publicIp !== "" ? vpn.publicIp : "unknown" }
     function backends(): string {
@@ -424,7 +440,7 @@ Panel {
     tooltipText: "VPN: " + vpn.barSummary
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) vpn.toggleActive()
-      else if (buttonCode === Qt.MiddleButton) { vpn.refreshAll(); vpn.refreshPublicIp() }
+      else if (buttonCode === Qt.MiddleButton) { vpn.refreshAll(true); vpn.refreshPublicIp() }
       else root.toggle()
     }
   }
@@ -455,7 +471,7 @@ Panel {
       onTextKey: function(t) {
         if (t === "/" && root.filterVisible) filterField.forceActiveFocus()
         else if (t === "d" || t === "D") { if (root.backend) root.backend.disconnect() }
-        else if (t === "r" || t === "R") { vpn.refreshAll(); vpn.refreshPublicIp() }
+        else if (t === "r" || t === "R") { vpn.refreshAll(true); vpn.refreshPublicIp() }
         else if (t === "s" || t === "S") { if (root.switcherVisible) root.stepBackend(1) }
       }
 
@@ -556,7 +572,11 @@ Panel {
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
               visible: root.masterSwitchVisible
-              checked: vpn.anyConnected
+              // The tool being looked at, not "anything at all". Flipping this
+              // calls toggleActive(), which acts on the selected backend — a
+              // switch reading "on" because a *different* tool is connected
+              // would take that tunnel down and bring this one up instead.
+              checked: root.backend ? root.backend.connected : false
               busy: root.backend ? root.backend.busy : false
               hasCursor: root.switchHasCursor
               foreground: root.foreground
@@ -565,7 +585,7 @@ Panel {
 
               PanelToolTip {
                 visible: masterSwitch.containsMouse
-                text: vpn.anyConnected ? "Disconnect" : "Connect"
+                text: masterSwitch.checked ? "Disconnect" : "Connect"
                 fontFamily: root.fontFamily
               }
             }
@@ -651,7 +671,7 @@ Panel {
             visible: root.statusLine !== ""
             width: parent.width
             text: root.statusLine
-            color: root.backend && root.backend.lastError !== "" && root.backend.actionStatus === "" ? root.urgent : root.dim
+            color: root.statusIsError ? root.urgent : root.dim
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
             wrapMode: Text.WordWrap

--- a/ProtonBackend.qml
+++ b/ProtonBackend.qml
@@ -60,8 +60,13 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
-  function detect() {
+  // Asked once. `force` is the user asking again, which is the only time the
+  // answer could have changed — see refreshAll() in VpnController.
+  property bool _probed: false
+
+  function detect(force) {
     if (detectProcess.running) return
+    if (_probed && force !== true) return
     detectProcess.running = true
   }
 
@@ -87,6 +92,7 @@ Item {
     _toggleKey = key
     toggleProcess.command = ["protonvpn"].concat(args)
     toggleProcess.running = true
+    pendingTimer.restart()
   }
 
   function applyConfig(raw) {
@@ -150,6 +156,22 @@ Item {
     if (_desired !== -1 && parsed.connected === (_desired === 1)) _desired = -1
   }
 
+  // A command that exits clean but does not take — the CLI accepts it and then
+  // lists the old value — would otherwise leave the switch showing the position
+  // the user asked for, marked busy, for as long as the panel is open. Optimism
+  // gets a deadline: past it, the switches go back to what the CLI actually
+  // says, which is the whole point of not storing them here.
+  Timer {
+    id: pendingTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (Object.keys(root._pendingToggles).length === 0) return
+      root._pendingToggles = ({})
+      root.lastError = "Proton VPN did not apply that setting."
+    }
+  }
+
   // The CLI reports the new state a beat after the command returns, so re-poll
   // a few times instead of waiting out the controller's refresh interval.
   Timer {
@@ -174,6 +196,7 @@ Item {
     command: ["omarchy-cmd-present", "protonvpn"]
     running: true
     onExited: function(exitCode) {
+      root._probed = true
       root.detected = exitCode === 0
       if (root.detected) root.refresh()
     }
@@ -243,6 +266,9 @@ Item {
     }
   }
 
+  // "Loaded" means asked and answered. A table this parser cannot read is a
+  // reason to say so once, not to re-fetch the list on every poll for as long
+  // as the shell runs.
   Process {
     id: countriesProcess
     running: false
@@ -252,6 +278,9 @@ Item {
       if (exitCode !== 0) return
       root.countries = Model.parseProtonCountries(String(countriesStdout.text || ""))
       root.countriesLoaded = true
+      if (root.countries.length === 0) {
+        root.lastError = "Could not read the country list. Check: protonvpn countries list"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ depending on what the cursor is on. `h`/`l` move along the chip row and between
 the gear and the master switch in the header, `s` cycles tools, `/` searches
 countries, `d` disconnects, `r` refreshes, `Esc` closes.
 
-The public IP is fetched from `checkip.amazonaws.com` — never on a timer, only
+The public IP is fetched from `https://checkip.amazonaws.com` — never on a timer, only
 when the connection changes, when the panel first opens, or when you ask.
 
 ## Requirements

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -140,14 +140,19 @@ Item {
     onTriggered: root.refreshPublicIp()
   }
 
+  // Over HTTPS, and not by accident: a bare hostname would leave curl on plain
+  // HTTP, where anyone between this machine and the exit — the very party a
+  // VPN is run against — could hand back any address they liked and have the
+  // panel present it as proof the tunnel works. `--fail` keeps an error body
+  // out of the answer; the parser rejects anything that is not an address.
   Process {
     id: ipProcess
     running: false
-    command: ["curl", "--silent", "--max-time", "6", "checkip.amazonaws.com"]
+    command: ["curl", "--silent", "--fail", "--max-time", "6", "https://checkip.amazonaws.com"]
     stdout: StdioCollector { id: ipStdout; waitForEnd: true }
     onExited: function(exitCode) {
       root.ipFetching = false
-      var address = String(ipStdout.text || "").trim()
+      var address = Model.parsePublicIp(String(ipStdout.text || ""))
       if (exitCode === 0 && address !== "") {
         root.publicIp = address
         root.ipFailed = false
@@ -195,13 +200,39 @@ Item {
     var backend = root.active
     if (!backend) return
     if (backend.connected) {
+      clearNotice()
       backend.disconnect()
       return
     }
     runExclusive(backend, function() { backend.toggleConnection() })
   }
 
+  // A warning about the connect that is about to run, kept here rather than on
+  // the backend's lastError — connectTo() clears that as its first act, so the
+  // action being warned about would wipe the warning on its way out. Expires on
+  // its own, since it describes one attempt and not a standing condition.
+  property string notice: ""
+
+  Timer {
+    id: noticeTimer
+    interval: 12000
+    repeat: false
+    onTriggered: root.notice = ""
+  }
+
+  function setNotice(text) {
+    root.notice = text
+    noticeTimer.restart()
+  }
+
+  function clearNotice() {
+    root.notice = ""
+    noticeTimer.stop()
+  }
+
   function runExclusive(backend, action) {
+    clearNotice()
+
     var others = otherConnected(backend)
     if (others.length === 0) {
       action()
@@ -213,14 +244,19 @@ Item {
       // down, which is exactly when the incoming connect needs the network.
       // Say so up front rather than let it fail as a timeout.
       if (others[i].lockdownMode === true) {
-        backend.lastError = others[i].label + " blocks all traffic while it is disconnected, "
-          + "so connecting will not get through. Turn it off with: mullvad lockdown-mode set off"
+        setNotice(others[i].label + " blocks all traffic while it is disconnected, "
+          + "so connecting will not get through. Turn it off with: mullvad lockdown-mode set off")
       }
       others[i].disconnect()
     }
+    // Picking a second target while the first is still waiting means the second
+    // one: nobody clicks two countries wanting both. The deadline stays where
+    // the first click put it, though — resetting it on every click would let an
+    // impatient user push the bail-out back indefinitely and leave the panel
+    // waiting on a teardown that is never going to land.
+    if (!exclusiveWait.running) exclusiveWait.ticks = 0
     root._pendingAction = action
     root._pendingBackend = backend
-    exclusiveWait.ticks = 0
     exclusiveWait.restart()
   }
 
@@ -259,9 +295,17 @@ Item {
 
   // A hidden tool is still probed — the settings view has to list it for you to
   // switch it back on — but never polled: not asking is the point of hiding it.
-  function refreshAll() {
+  //
+  // Binaries do not come and go while the shell runs, so a tool that answered
+  // "not installed" is asked once and then left alone; the poll would otherwise
+  // spawn a probe per missing tool every interval, forever, to re-answer a
+  // question whose answer never changed. `force` is the user asking — opening
+  // the panel, pressing r, middle-clicking the icon — which is exactly when
+  // something might have been installed since.
+  function refreshAll(force) {
+    var recheck = force === true
     for (var i = 0; i < backends.length; i++) {
-      if (!backends[i].detected) backends[i].detect()
+      if (!backends[i].detected) backends[i].detect(recheck)
       else if (!isHidden(backends[i].backendId)) backends[i].refresh()
     }
   }

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,0 +1,429 @@
+// Tests for Model.js — the pure half of the widget, where every assumption
+// about how three CLIs format their output is written down.
+//
+//   node tests/run.js
+//
+// No dependencies and no test framework: the plugin ships no package.json and
+// is not built, so a test suite that needed installing would not get run.
+//
+// Model.js is a QML `.pragma library`, which has no module system — just
+// top-level declarations. Running it in this realm's global scope turns those
+// into globals, which is as close to importing it as node gets without a QML
+// engine; collecting the names it added gives back something shaped like a
+// module. A fresh VM context would be tidier, but its arrays would carry that
+// context's prototypes and every deepStrictEqual would fail on realm alone.
+
+const fs = require("fs")
+const path = require("path")
+const vm = require("vm")
+const assert = require("assert")
+
+const source = fs.readFileSync(path.join(__dirname, "..", "Model.js"), "utf8")
+  .replace(/^\s*\.pragma\s+library\s*$/m, "")
+
+const before = new Set(Object.getOwnPropertyNames(globalThis))
+vm.runInThisContext(source, { filename: "Model.js" })
+
+const Model = {}
+for (const name of Object.getOwnPropertyNames(globalThis)) {
+  if (!before.has(name)) Model[name] = globalThis[name]
+}
+
+let passed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed += 1
+  } catch (error) {
+    failures.push({ name: name, error: error })
+  }
+}
+
+const eq = assert.deepStrictEqual
+
+// ------------------------------------------------------------------ shared
+
+test("elide keeps short text and collapses whitespace", () => {
+  eq(Model.elide("  a   b  ", 10), "a b")
+  eq(Model.elide("abcdefghij", 10), "abcdefghij")
+  eq(Model.elide("abcdefghijk", 10), "abcdefghi…")
+  eq(Model.elide(null, 10), "")
+})
+
+test("applyPendingToggles marks only the flipped switch busy", () => {
+  const toggles = [Model.toggle("a", "A", "", false), Model.toggle("b", "B", "", true)]
+  const applied = Model.applyPendingToggles(toggles, { a: true })
+  eq(applied[0].value, true)
+  eq(applied[0].busy, true)
+  eq(applied[1].value, true)
+  eq(applied[1].busy, false)
+  eq(Model.applyPendingToggles(toggles, null), toggles)
+})
+
+test("backend id lists round-trip through the comma-separated setting", () => {
+  eq(Model.parseBackendIds(" Proton , mullvad ,, proton "), ["proton", "mullvad"])
+  eq(Model.parseBackendIds(null), [])
+  eq(Model.joinBackendIds(["proton", "mullvad"]), "proton,mullvad")
+  eq(Model.toggleBackendId(["proton"], "mullvad"), ["proton", "mullvad"])
+  eq(Model.toggleBackendId(["proton", "mullvad"], "proton"), ["mullvad"])
+})
+
+// --------------------------------------------------------------- public IP
+
+test("parsePublicIp accepts address literals", () => {
+  eq(Model.parsePublicIp("1.2.3.4"), "1.2.3.4")
+  eq(Model.parsePublicIp("  8.8.8.8\n"), "8.8.8.8")
+  eq(Model.parsePublicIp("2001:DB8::1"), "2001:db8::1")
+})
+
+test("parsePublicIp rejects anything that is not one", () => {
+  // A captive portal's login page, an error body, a spoofed answer with a
+  // trailer: none of these are an exit address, and rendering one would be the
+  // widget confirming a route it never saw.
+  eq(Model.parsePublicIp("<html>Sign in</html>"), "")
+  eq(Model.parsePublicIp("1.2.3.4 extra"), "")
+  eq(Model.parsePublicIp("999.1.1.1"), "")
+  eq(Model.parsePublicIp("deadbeef"), "")
+  eq(Model.parsePublicIp("1:2:::3"), "")
+  eq(Model.parsePublicIp("::1::2"), "")
+  eq(Model.parsePublicIp(""), "")
+  eq(Model.parsePublicIp(null), "")
+  eq(Model.parsePublicIp("1.2.3.4".padEnd(50, "0")), "")
+})
+
+// ------------------------------------------------------------- Proton VPN
+
+test("parseProtonStatus reads the labelled block", () => {
+  const status = Model.parseProtonStatus([
+    "Status: Connected",
+    "Server: NL#42",
+    "Country: Netherlands",
+    "Load: 40%",
+    "Protocol: WireGuard"
+  ].join("\n"))
+  eq(status.connected, true)
+  eq(status.server, "NL#42")
+  eq(status.country, "Netherlands")
+  eq(status.load, "40%")
+  eq(status.protocol, "WireGuard")
+})
+
+test("parseProtonStatus splits the combined server-and-place field", () => {
+  const status = Model.parseProtonStatus("Status: Connected\nServer: CH#1129 in Zurich, Switzerland")
+  eq(status.server, "CH#1129")
+  eq(status.city, "Zurich")
+  eq(status.country, "Switzerland")
+  eq(Model.protonSummary(status), "CH#1129 · Zurich, Switzerland")
+})
+
+test("parseProtonStatus reads the older bare sentence", () => {
+  const status = Model.parseProtonStatus("Connected to NL#42")
+  eq(status.connected, true)
+  eq(status.server, "NL#42")
+})
+
+test("parseProtonStatus treats disconnected and noise as not connected", () => {
+  eq(Model.parseProtonStatus("Status: Disconnected").connected, false)
+  eq(Model.parseProtonStatus("").connected, false)
+  eq(Model.parseProtonStatus("garbage\n\n---").connected, false)
+  eq(Model.parseProtonStatus("").statusText, "Disconnected")
+  eq(Model.protonSummary(Model.parseProtonStatus("")), "Not connected")
+})
+
+test("parseProtonCountries skips the header, the rule, and the notice", () => {
+  eq(Model.parseProtonCountries([
+    "Server list is outdated, updating...",
+    "Country                  Code",
+    "-----------------------  ----",
+    "Netherlands              NL",
+    "United States            US"
+  ].join("\n")), [
+    { name: "Netherlands", code: "NL" },
+    { name: "United States", code: "US" }
+  ])
+})
+
+test("parseProtonConfig reads the two-column table", () => {
+  const config = Model.parseProtonConfig([
+    "Setting                  Value",
+    "-----------------------  ------------",
+    "netshield                malware-only",
+    "kill-switch              off"
+  ].join("\n"))
+  eq(config.loaded, true)
+  eq(config.values["netshield"], "malware-only")
+  eq(config.values["kill-switch"], "off")
+  eq(Model.parseProtonConfig("").loaded, false)
+})
+
+test("protonToggles reports mode-carrying settings as on", () => {
+  const config = Model.parseProtonConfig("netshield  malware-only\nkill-switch  advanced")
+  const toggles = Model.protonToggles(config)
+  eq(toggles.map(t => t.key), ["kill-switch", "netshield", "port-forwarding"])
+  eq(toggles[0].value, true)
+  eq(toggles[0].detail, "Mode: advanced")
+  eq(toggles[1].value, true)
+  eq(toggles[1].detail, "Blocking: malware-only")
+  eq(toggles[2].value, false)
+  eq(Model.protonToggles(Model.parseProtonConfig("")), [])
+})
+
+test("protonToggleArgs restores the remembered mode instead of a default", () => {
+  // Switching NetShield off and on again must not silently upgrade a
+  // deliberate "malware-only" to the wider default.
+  eq(Model.protonToggleArgs("netshield", true, "malware-only"),
+    ["config", "set", "netshield", "malware-only"])
+  eq(Model.protonToggleArgs("netshield", true, ""),
+    ["config", "set", "netshield", "malware-ads-trackers"])
+  eq(Model.protonToggleArgs("kill-switch", true, ""),
+    ["config", "set", "kill-switch", "standard"])
+  eq(Model.protonToggleArgs("netshield", false, "malware-only"),
+    ["config", "set", "netshield", "off"])
+  eq(Model.protonToggleArgs("nonsense", true, ""), [])
+})
+
+test("protonModes remembers the last non-off value", () => {
+  const first = Model.protonModes(Model.parseProtonConfig("netshield  malware-only"), {})
+  eq(first["netshield"], "malware-only")
+  const after = Model.protonModes(Model.parseProtonConfig("netshield  off"), first)
+  eq(after["netshield"], "malware-only")
+})
+
+test("protonCountryTargets puts favorites first and filters over name and code", () => {
+  const countries = [
+    { name: "Netherlands", code: "NL" },
+    { name: "Switzerland", code: "CH" }
+  ]
+  eq(Model.protonCountryTargets(countries, ["CH"], "").map(t => t.label),
+    ["Switzerland", "Netherlands"])
+  eq(Model.protonCountryTargets(countries, ["CH"], "nl").map(t => t.label), ["Netherlands"])
+  eq(Model.protonCountryTargets(countries, [], "zzz"), [])
+  eq(Model.protonCountryTargets(countries, [], "")[0].args, ["--country", "NL"])
+})
+
+test("favoriteCodes normalises and de-duplicates", () => {
+  eq(Model.favoriteCodes(" ch , NL ,ch, "), ["CH", "NL"])
+  eq(Model.favoriteCodes(null), [])
+})
+
+// ----------------------------------------------------------- NetworkManager
+
+test("splitNmcliLine splits on the first unescaped colon", () => {
+  eq(Model.splitNmcliLine("home\\:vpn:uuid-1"), ["home:vpn", "uuid-1"])
+  eq(Model.splitNmcliLine("plain"), ["plain", ""])
+})
+
+test("parseNmcliConnections keeps only tunnels", () => {
+  eq(Model.parseNmcliConnections([
+    "Work VPN:uuid-1:vpn:yes:/etc/NetworkManager/system-connections/work.nmconnection",
+    "Home WG:uuid-2:wireguard:no:/etc/NetworkManager/system-connections/home.nmconnection",
+    "Wired:uuid-3:ethernet:yes:/etc/NetworkManager/system-connections/wired.nmconnection",
+    ""
+  ].join("\n")), [
+    { name: "Work VPN", uuid: "uuid-1", kind: "vpn", active: true },
+    { name: "Home WG", uuid: "uuid-2", kind: "wireguard", active: false }
+  ])
+})
+
+test("parseNmcliConnections drops another tool's volatile connection", () => {
+  // Mullvad brings up wg0-mullvad itself; NetworkManager adopts the device and
+  // generates a profile under /run. Listing it would put one tunnel on two
+  // chips and let nmcli yank it out from under the tool that owns it.
+  eq(Model.parseNmcliConnections(
+    "wg0-mullvad:uuid-9:wireguard:yes:/run/NetworkManager/system-connections/wg0-mullvad.nmconnection"
+  ), [])
+})
+
+test("parseNmcliConnections keeps rows from an nmcli with no FILENAME field", () => {
+  // The older-nmcli fallback: the field is dropped from the query and the
+  // connection is kept, since a stray row beats a backend that lists nothing.
+  eq(Model.parseNmcliConnections("Work VPN:uuid-1:vpn:yes"), [
+    { name: "Work VPN", uuid: "uuid-1", kind: "vpn", active: true }
+  ])
+})
+
+test("parseNmcliVpnDetails reads one block per connection", () => {
+  const details = Model.parseNmcliVpnDetails([
+    "connection.uuid:uuid-1",
+    "vpn.service-type:org.freedesktop.NetworkManager.openvpn",
+    "vpn.data:username = alice, comp-lzo = adaptive",
+    "",
+    "connection.uuid:uuid-2",
+    "vpn.service-type:org.freedesktop.NetworkManager.fortisslvpn",
+    "vpn.data:comp-lzo = adaptive"
+  ].join("\n"))
+  eq(Object.keys(details).sort(), ["uuid-1", "uuid-2"])
+  eq(details["uuid-1"].hasUsername, true)
+  eq(Model.isOpenVpnService(details["uuid-1"].serviceType), true)
+  eq(details["uuid-2"].hasUsername, false)
+  eq(Model.isOpenVpnService(details["uuid-2"].serviceType), false)
+})
+
+test("hasVpnUsername ignores an empty username", () => {
+  eq(Model.hasVpnUsername("username = alice"), true)
+  eq(Model.hasVpnUsername("username = "), false)
+  eq(Model.hasVpnUsername("comp-lzo = adaptive"), false)
+  eq(Model.hasVpnUsername(""), false)
+})
+
+test("nmTargets flags an OpenVPN profile with no username", () => {
+  const targets = Model.nmTargets([
+    { name: "Work", uuid: "uuid-1", kind: "vpn", active: false, hasUsername: false },
+    { name: "Home", uuid: "uuid-2", kind: "wireguard", active: false },
+    { name: "Live", uuid: "uuid-3", kind: "vpn", active: true, hasUsername: true }
+  ])
+  eq(targets[0].detail, "No username set")
+  // WireGuard keeps its keys in the profile, so there is nothing to leave out.
+  eq(targets[1].detail, "WireGuard profile")
+  eq(targets[2].detail, "Connected")
+  eq(targets[0].args, ["connection", "up", "uuid", "uuid-1"])
+})
+
+test("nmSummary tells no profiles from none connected", () => {
+  eq(Model.nmSummary([]), "No profiles")
+  eq(Model.nmSummary([{ name: "Work", active: false }]), "Not connected")
+  eq(Model.nmSummary([{ name: "Work", active: true }]), "Work")
+})
+
+// ------------------------------------------------------------------ Mullvad
+
+test("parseMullvadStatus reads a connected payload", () => {
+  const status = Model.parseMullvadStatus(JSON.stringify({
+    state: "connected",
+    details: {
+      location: { hostname: "ch-zrh-wg-001", country: "Switzerland", city: "Zurich", ipv4: "1.2.3.4" },
+      endpoint: { address: "185.156.46.146:51820", protocol: "udp", tunnel_interface: "wg0-mullvad" },
+      feature_indicators: ["QuantumResistance"]
+    }
+  }))
+  eq(status.connected, true)
+  eq(status.relay, "ch-zrh-wg-001")
+  eq(status.protocol, "UDP")
+  eq(status.features, ["Quantum Resistance"])
+  eq(Model.mullvadSummary(status), "ch-zrh-wg-001 · Zurich, Switzerland")
+})
+
+test("parseMullvadStatus treats unparseable output as no idea", () => {
+  // Not as disconnected: claiming the tunnel is down when the answer was
+  // unreadable is the wrong direction to guess in.
+  eq(Model.parseMullvadStatus("not json").state, "")
+  eq(Model.parseMullvadStatus("").state, "")
+  eq(Model.parseMullvadStatus("[1,2]").state, "")
+  eq(Model.mullvadSummary(Model.parseMullvadStatus("")), "Checking…")
+})
+
+test("parseMullvadStatus survives details being a bare string", () => {
+  const status = Model.parseMullvadStatus('{"state":"disconnecting","details":"reconnect"}')
+  eq(status.state, "disconnecting")
+  eq(status.connected, false)
+})
+
+test("mullvadSummary names the blocked state for what it is", () => {
+  const blocked = Model.parseMullvadStatus('{"state":"error"}')
+  eq(blocked.blocked, true)
+  eq(Model.mullvadSummary(blocked), "Blocked — no traffic is leaving this machine")
+  const lockedDown = Model.parseMullvadStatus('{"state":"disconnected","details":{"locked_down":true}}')
+  eq(Model.mullvadSummary(lockedDown), "Not connected · traffic blocked")
+})
+
+test("mullvadIndentDepth counts a tab and four spaces alike", () => {
+  eq(Model.mullvadIndentDepth("Switzerland (ch)"), 0)
+  eq(Model.mullvadIndentDepth("\tZurich (zrh)"), 1)
+  eq(Model.mullvadIndentDepth("    Zurich (zrh)"), 1)
+  eq(Model.mullvadIndentDepth("\t\tch-zrh-wg-001"), 2)
+})
+
+test("parseMullvadRelays keeps countries and cities, not relays", () => {
+  eq(Model.parseMullvadRelays([
+    "Switzerland (ch)",
+    "\tZurich (zrh) @ 47.36667°N, 8.55000°W",
+    "\t\tch-zrh-wg-001 (185.156.46.146) - hosted by 31173 (rented)",
+    "Netherlands (nl)",
+    "\tAmsterdam (ams) @ 52.35°N, 4.9°E"
+  ].join("\n")), [
+    { name: "Switzerland", code: "CH", cities: [{ name: "Zurich", code: "zrh" }] },
+    { name: "Netherlands", code: "NL", cities: [{ name: "Amsterdam", code: "ams" }] }
+  ])
+  eq(Model.parseMullvadRelays(""), [])
+})
+
+test("mullvadCountryTargets filters over city names too", () => {
+  const countries = Model.parseMullvadRelays([
+    "Switzerland (ch)",
+    "\tZurich (zrh)",
+    "Netherlands (nl)",
+    "\tAmsterdam (ams)"
+  ].join("\n"))
+  eq(Model.mullvadCountryTargets(countries, [], "zurich").map(t => t.label), ["Switzerland"])
+  eq(Model.mullvadCountryTargets(countries, ["NL"], "").map(t => t.label),
+    ["Netherlands", "Switzerland"])
+  eq(Model.mullvadCountryTargets(countries, [], "")[0].detail, "CH · 1 city")
+  eq(Model.mullvadCountryTargets(countries, [], "")[0].args, ["ch"])
+})
+
+test("mullvadCurrentKey prefers the hostname over the country name", () => {
+  const countries = [{ name: "Switzerland", code: "CH", cities: [] }]
+  eq(Model.mullvadCurrentKey({ state: "connected", relay: "ch-zrh-wg-504", country: "" }, countries),
+    "country:CH")
+  // Mid-connect the hostname is not reported yet, so the name has to carry it.
+  eq(Model.mullvadCurrentKey({ state: "connecting", relay: "", country: "Switzerland" }, countries),
+    "country:CH")
+  eq(Model.mullvadCurrentKey({ state: "disconnected", relay: "ch-zrh-wg-504", country: "" }, countries), "")
+})
+
+test("parseMullvadSettings marks each answer it actually saw", () => {
+  const all = Model.parseMullvadSettings([
+    "Autoconnect: off",
+    "Block traffic when the VPN is disconnected: on",
+    "Local network sharing setting: allow"
+  ].join("\n"))
+  eq(all.loaded, true)
+  eq(all.autoconnect, false)
+  eq(all.lockdown, true)
+  eq(all.lan, true)
+  eq(all.seen, { autoconnect: true, lockdown: true, lan: true })
+})
+
+test("parseMullvadSettings does not report an unanswered setting as off", () => {
+  // One shell, one exit code — the last subcommand's — so a failed
+  // `lockdown-mode get` leaves no line and no error. Reporting lockdown mode as
+  // off while it is on is the one mistake this widget must not make.
+  const partial = Model.parseMullvadSettings("Autoconnect: on\n")
+  eq(partial.loaded, true)
+  eq(partial.seen, { autoconnect: true })
+  eq(Model.mullvadToggles(partial).map(t => t.key), ["autoconnect"])
+
+  // Each branch answers for itself and for nothing else — the middle
+  // subcommand succeeding says nothing about the two around it.
+  const middle = Model.parseMullvadSettings("Block traffic when the VPN is disconnected: on\n")
+  eq(middle.seen, { lockdown: true })
+  eq(Model.mullvadToggles(middle).map(t => t.key), ["lockdown"])
+  const last = Model.parseMullvadSettings("Local network sharing setting: allow\n")
+  eq(last.seen, { lan: true })
+  eq(Model.mullvadToggles(last).map(t => t.key), ["lan"])
+
+  const none = Model.parseMullvadSettings("")
+  eq(none.loaded, false)
+  eq(none.seen, {})
+  eq(Model.mullvadToggles(none), [])
+})
+
+test("mullvadToggleArgs speaks each setting's own vocabulary", () => {
+  eq(Model.mullvadToggleArgs("autoconnect", true), ["auto-connect", "set", "on"])
+  eq(Model.mullvadToggleArgs("lockdown", false), ["lockdown-mode", "set", "off"])
+  eq(Model.mullvadToggleArgs("lan", true), ["lan", "set", "allow"])
+  eq(Model.mullvadToggleArgs("lan", false), ["lan", "set", "block"])
+  eq(Model.mullvadToggleArgs("nonsense", true), [])
+})
+
+// ------------------------------------------------------------------ report
+
+for (const failure of failures) {
+  console.error("FAIL  " + failure.name)
+  console.error("      " + String(failure.error.message).split("\n").join("\n      "))
+}
+
+console.log(`${passed} passed, ${failures.length} failed`)
+process.exit(failures.length === 0 ? 0 : 1)


### PR DESCRIPTION
An adversarial review of the whole plugin turned up thirteen defects. Fixed here, worst first.

### The panel showing protection it never verified

- **The master switch disconnected nothing — it swapped tunnels.** `checked` was bound to `anyConnected` while the click acted on the *selected* backend. Mullvad up, Proton chip picked: the switch read "Disconnect", and clicking it tore Mullvad down and brought Proton up, with an unprotected gap in between. Now bound to the backend it actually drives.
- **Mullvad settings reported unanswered as off.** The three settings are read in one `bash -c`, and one shell reports one exit code — the last subcommand's. A failed `lockdown-mode get` left no line and no error, so lockdown mode was drawn as disabled while enabled, and the pre-flight warning in `runExclusive` was silently disarmed. The parser now records which answers arrived (`seen`) and draws a switch only for those; a read that answered nothing leaves the last known state alone.
- **Public IP fetched over plaintext HTTP, unvalidated.** A bare hostname leaves curl on `http://`, so anyone on the path — the exact adversary a VPN is run against — could forge the address the panel presents as proof the tunnel works. Now `https://` with `--fail`, and the response is believed only if it parses as an address literal, so a captive portal's login page reaches neither the display nor the clipboard.

### State that could not recover

- The lockdown warning was written to `backend.lastError`, which `connectTo()` clears as its first act — the action being warned about erased the warning. It now lives on the controller with its own expiry.
- An optimistic toggle whose command exited clean but did not take stayed on screen, busy, forever. Optimism now has a 10s deadline.
- nmcli rejects a listing naming a field it does not know, so an nmcli too old for `FILENAME` returned *nothing* rather than rows without it, and the backend silently never appeared. The first refusal drops the field and lists again. (The comment claiming this fallback already existed is corrected.)
- A failed details pass emptied the profile list, taking the chip away mid-tunnel — and with it the only way to bring that tunnel down, since `disconnect()` guards on `detected`. It now keeps the last known list.
- The two nmcli discovery passes share one buffer; `refresh()` now waits for both.

### Polling and interaction

- `relaysLoaded` keyed off the parsed count, so a format change re-ran the CLI's largest output every poll, forever, with no explanation on screen. Loaded now means asked and answered, and an empty parse says so.
- A backend that answered "not installed" is no longer re-probed by the background poll — only when the user asks (panel open, `r`, middle click, IPC `refresh`), which is when something might have been installed since.
- A second connect request while the first waits now supersedes it without pushing the bail-out deadline back.
- The filter field is cleared at both ends on a chip change, so it cannot show text the list is not filtered by.

### Tests

`Model.js` is the one file that runs without a QML engine and the one where every assumption about three CLIs' output formats lives. It now has a suite: **35 cases**, stdlib only, no `package.json` — a suite that needed installing would not get run.

```bash
node tests/run.js
```

CI runs it on push and PR. Three seeded regressions (lockdown branch over-claiming, `parsePublicIp` trusting any body, volatile-connection filter disabled) confirm it fails when it should — the first one initially survived, so the partial-read cases were tightened until it didn't.

### Not covered

Findings 14+ from the review were NOTE-level and are untouched: positional `parent.children[]` indices in `InfoPair`, `saveSetting` failing silently when `updateEntryInline` is absent, IPC `connect` matching on the display-only `detail` field, an unquoted profile name in one suggested command, and `PATH`-resolved binaries.

None of this has been exercised against a live shell — `qmllint` clean per file, tests green. `qmllint` exits 255 on any multi-file invocation in this environment, reproducible on pristine `main` and on the same file passed twice, so CI keeps to the node suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
