### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  model:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # No install step: the suite is stdlib-only on purpose, so it runs the
+      # same way here as it does on a machine with the plugin checked out.
+      - run: node tests/run.js

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ duck-types, so a backend that omits something simply renders as blank.
 
 | Property | Meaning |
 |----------|---------|
-| `detected` | Tool is installed and usable. Everything else is ignored until this is true |
+| `detected` | Tool is installed and has something to offer. Everything else is ignored until this is true |
 | `connected` | A tunnel is up |
 | `summary` | One line under the hero title |
 | `details` | `[{ label, value }]` rows shown while connected |
@@ -59,6 +59,11 @@ asks the user to pick.
 A backend may also expose `lockdownMode`, meaning "this tool blocks all traffic
 while it is disconnected". The controller warns about it before tearing that
 backend down for another one.
+
+It may also expose `setupHint`: one line explaining why it is not `detected`
+and what would change that. The panel shows the first non-empty hint in place
+of its own "install a VPN tool" line, which is the wrong advice for a tool that
+is installed and merely has nothing to connect to yet.
 
 ## Adding a backend
 
@@ -112,6 +117,25 @@ state lives on the panel, so it survives a close and reopen but not a shell
 restart, and folding the drawer while the cursor is inside it moves the cursor
 back to the hero rather than stranding it.
 
+**Two kinds of settings, two places.** The drawer above holds the *tool's*
+settings, which the widget only reflects. The gear in the header holds the
+*widget's* own, which it owns and must persist — currently one switch per
+detected tool. It writes through `bar.shell.updateEntryInline(moduleName,
+settings)` into this widget's entry in `~/.config/omarchy/shell.json`, the same
+file and entry Omarchy's settings dialog edits, so the two never disagree.
+`settings` arrives holding only the inline overrides, so writing it back cannot
+bake today's defaults into the config.
+
+Hidden tools are dropped from `availableBackends`: no chip, no polling, no
+weight in the bar icon, and exclusivity never tears them down. They are still
+probed, since the settings view has to list a hidden tool for you to switch it
+back on, and `detectedBackends` — everything present, hidden or not — is what
+that view renders. Hiding is a view, not a drawer: it replaces the body, because
+nothing in the connect list means anything while you are deciding which tools
+the widget should know about. It resets on close, unlike the tool drawer, and
+the gear stays reachable with the master switch gone so a widget with everything
+hidden is not a dead end.
+
 While a switch is in flight it shows the position the user just asked for, with
 `busy` set. The optimistic value is dropped only for the keys the tool has since
 agreed with, so a poll landing mid-flight cannot flick the other switches back —
@@ -157,6 +181,17 @@ NetworkManager keeps it outside the secrets store, so `nmcli --ask` never
 prompts for it — a profile without one authenticates as the empty user and the
 server answers `AUTH_FAILED`. The backend detects that case and reports the fix
 instead of opening a terminal that cannot succeed.
+
+**Eligibility, not just installation.** NetworkManager ships on every desktop,
+so "nmcli is here" says nothing about whether this machine has a tunnel to
+offer. It is `detected` only while at least one eligible profile exists — one
+whose kind matches an installed tool (`openvpn` for OpenVPN profiles, `wg` for
+WireGuard ones), since NetworkManager lists an OpenVPN profile whether or not
+anything can run it. With no eligible profile the backend disappears, and with
+it the chip, the hero, and the empty list they led to; the import instructions
+move to the panel's `setupHint` line so nothing is lost. Because `detected` now
+follows the profile list, `detect()` stays callable every poll: the binary
+probes run once, and after that it is a plain `refresh()`.
 
 **FILENAME is what keeps other tools' tunnels out.** When something brings up a
 WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,9 +47,14 @@ duck-types, so a backend that omits something simply renders as blank.
 
 **Verbs**
 
-`detect()`, `refresh()`, `connectTo(target)`, `disconnect()`,
+`detect(force)`, `refresh()`, `connectTo(target)`, `disconnect()`,
 `toggleConnection()`, and `setToggle(key, value)` for a backend that offers
 `toggles`.
+
+`detect(force)` probes and nothing else — it must not fall through to a
+`refresh()`, because a hidden backend is given `detect()` alone and would
+otherwise keep polling a tool the user switched off. `refresh()` guards itself,
+so the controller can call it unconditionally.
 
 `toggleConnection()` is the backend's own idea of a default connection — Proton
 picks the fastest server; Mullvad reuses its stored relay constraint;
@@ -81,6 +86,15 @@ contract.
 connected backend, wait for them to report down (700ms polls, ~10s cap, then
 proceed anyway so a stuck teardown cannot swallow the user's connect), and only
 then bring the new tunnel up.
+
+Every *disconnect* goes through `disconnectActive()` for the mirror-image
+reason: the connect waiting on that teardown is part of what is being withdrawn,
+and a queued action nobody cancelled fires seconds later and reconnects the
+tunnel the user just asked to bring down. Picking a second target cancels the
+first for the same reason — nobody clicks two countries wanting both — which
+matters most when the teardown finished between the click and the next poll, so
+the second connect takes the "nothing to wait for" path and would otherwise
+leave the first one queued behind it.
 
 **Optimistic state.** Both backends keep a `_desired` field: `-1` follows
 reality, `0`/`1` overrides it while a command is in flight. That is what makes
@@ -193,8 +207,8 @@ WireGuard ones), since NetworkManager lists an OpenVPN profile whether or not
 anything can run it. With no eligible profile the backend disappears, and with
 it the chip, the hero, and the empty list they led to; the import instructions
 move to the panel's `setupHint` line so nothing is lost. Because `detected` now
-follows the profile list, `detect()` stays callable every poll: the binary
-probes run once, and after that it is a plain `refresh()`.
+follows the profile list, the question is settled by `refresh()` rather than by
+`detect()`, which runs its three binary probes once and is a no-op after that.
 
 **FILENAME is what keeps other tools' tunnels out.** When something brings up a
 WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the
@@ -256,8 +270,14 @@ it:
 
 ```bash
 node tests/run.js
-qmllint *.qml          # one file per invocation; a batch exits 255 regardless
+(cd .. && qmllint -I /usr/share/omarchy/shell jkoestinger.vpn/Panel.qml)
 ```
+
+One file per invocation, and never from inside the plugin directory. qmllint
+treats the directory it is pointed at as an implicit import, which makes
+`Panel.qml` — a `Panel` deriving from `qs.Ui`'s `Panel` — resolve to itself and
+crash with exit 255 and no message. A batch invocation adds the same directory
+for the same reason. Neither is a defect in the file being checked.
 
 No framework and no `package.json` — a suite that needed installing would not
 get run, and the plugin is not built. `tests/run.js` evaluates `Model.js` in the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,10 @@ the switch flip the instant it is clicked instead of waiting a poll cycle.
 Reality reasserts itself once the tool agrees, or after the settle timer gives
 up.
 
-**Public IP.** Fetched with `curl checkip.amazonaws.com`, never polled. The
+**Public IP.** Fetched with `curl https://checkip.amazonaws.com`, never polled.
+The scheme is explicit — over plain HTTP anyone on the path could forge the
+address the panel presents as proof the tunnel works — and the response is only
+believed if it parses as an address literal. The
 trigger is `connectionKey` — a string built from the connected backend's id and
 summary — so a connect, a disconnect, or a server switch all invalidate it. A
 2s delay lets routes settle first, since asking too early returns the old
@@ -244,3 +247,24 @@ registered for target …` appears once per extra monitor. Every first-party
 widget logs the same thing; it is not a defect.
 
 Check a manifest change with `omarchy plugin validate .` before committing.
+
+## Tests
+
+`Model.js` is where every assumption about how three CLIs format their output
+lives, and it is the one file that runs without a QML engine. The suite covers
+it:
+
+```bash
+node tests/run.js
+qmllint *.qml          # one file per invocation; a batch exits 255 regardless
+```
+
+No framework and no `package.json` — a suite that needed installing would not
+get run, and the plugin is not built. `tests/run.js` evaluates `Model.js` in the
+node realm and collects the names it declares, since a `.pragma library` has no
+exports. CI runs the same command on push and pull request.
+
+The QML halves are not covered: they are `Process` plumbing and bindings, and
+the interesting logic was pushed into `Model.js` precisely so it could be
+tested. When a bug turns out to live in a parser, the fix belongs there with a
+case beside it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+## 1.1.0
+
+### Added
+
+- **Widget settings, behind the gear in the panel header.** One switch per VPN
+  tool found on this machine. Turn one off and the widget forgets it entirely:
+  no chip, no polling, and it stops counting toward the bar icon. The choice is
+  written to `~/.config/omarchy/shell.json` as `hiddenBackends`, the same entry
+  Omarchy's own settings dialog edits, so the two never disagree.
+- **A tool with nothing to offer no longer draws a chip.** NetworkManager ships
+  on every desktop, so "nmcli is here" said nothing about whether this machine
+  had a tunnel to offer. It now appears only once an eligible profile exists —
+  an OpenVPN one with `openvpn` installed, or a WireGuard one with
+  `wireguard-tools` — and the import instructions move to the panel's setup
+  line rather than sitting behind a chip that led to an empty list.
+
+### Fixed
+
+- **The master switch could take down the wrong tunnel.** It bound its position
+  to "anything is connected" while its click acted on the tool being looked at,
+  so with Mullvad up and the Proton chip picked it read "Disconnect" and then
+  tore Mullvad down and brought Proton up. It now follows the backend it drives.
+- **Mullvad's lockdown mode could be drawn as off while it was on.** The three
+  settings are read in one shell, and one shell has one exit code — the last
+  subcommand's — so a failed `lockdown-mode get` left no line and no error, and
+  the parser read the silence as "off". That also silently disarmed the warning
+  shown before Mullvad is torn down for another tool. The parser now records
+  which answers arrived and draws a switch only for those; a read that answered
+  nothing leaves the last known state alone.
+- **The public IP was fetched over plain HTTP.** A bare hostname left curl on
+  port 80, where anyone between this machine and the exit — the very party a VPN
+  is run against — could hand back any address and have the panel present it as
+  proof the tunnel works. It is HTTPS now, with `--fail`, and the response is
+  believed only if it parses as an address literal, so a captive portal's login
+  page reaches neither the display nor the clipboard.
+- **A cancelled connect could come back to life.** A connect queued behind
+  another tool's teardown was never cancelled, so pressing `d`, flipping the
+  master switch off, or picking a second country left the first request in the
+  exclusivity timer, which fired seconds later and brought up a tunnel the user
+  had already called off.
+- **`connect <country code>` over IPC only worked for Proton VPN.** It matched
+  the row's detail line, and Mullvad's carries a city count after the code
+  (`CH · 3 cities`), so the shorthand the README documents answered
+  `unknown target`. It now matches the row key, which every backend spells the
+  same way.
+- **A hidden NetworkManager kept polling `nmcli` every interval**, which is the
+  one thing hiding a tool is supposed to stop.
+- The lockdown warning was written to the backend's `lastError`, which
+  `connectTo()` clears as its first act — so the action being warned about
+  erased the warning on its way out. It lives on the controller now, with an
+  expiry of its own.
+- An optimistic switch whose command exited clean but never took would sit
+  showing the position the user asked for, marked busy, for as long as the panel
+  stayed open. Optimism now has a deadline.
+- Turning NetShield or the kill switch off and on again restored the mode it had
+  rather than silently upgrading a deliberate `malware-only` to the wider
+  default.
+- A relay or country list the parser could not read was re-fetched on every poll
+  for as long as the shell ran, while the panel showed nothing and no reason why.
+- An `nmcli` too old to report `FILENAME` rejected the whole listing rather than
+  answering without the field, so the NetworkManager backend silently never
+  appeared. The first refusal now drops the field and lists again.
+- A failed NetworkManager details pass emptied the profile list, which took the
+  chip away mid-tunnel — and with it the only way to bring that tunnel down. It
+  keeps the last known list now.
+- The filter field is cleared at both ends when the chip changes, so it cannot
+  show text the list is not filtered by.
+
+### Internal
+
+- `Model.js`, where every assumption about three CLIs' output formats lives, now
+  has a test suite: 35 cases, stdlib only, no `package.json`, run with
+  `node tests/run.js` and on every push and pull request.
+
+## 1.0.0
+
+First release. Proton VPN, Mullvad, and NetworkManager's OpenVPN and WireGuard
+profiles behind one bar icon, with exclusivity between them, a public-IP
+readout, keyboard navigation, and an IPC surface for scripts.

--- a/Model.js
+++ b/Model.js
@@ -15,6 +15,33 @@ var GLYPH_COG = String.fromCodePoint(0xF0493)
 
 // ----------------------------------------------------------------- shared
 
+// The exit address lookup answers with a bare address and nothing else. A
+// captive portal's login page, a proxy's error body, or anything else that
+// came back with it is not an answer — and this is the one number a user reads
+// to decide whether the tunnel is carrying their traffic, so rendering
+// whatever arrived would be the widget confirming a route it never saw.
+// Returns "" for anything that is not an address literal.
+function parsePublicIp(raw) {
+  var text = String(raw || "").trim()
+  // Longest possible IPv6 text form; anything longer is not an address.
+  if (text === "" || text.length > 45) return ""
+
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(text)) {
+    var octets = text.split(".")
+    for (var i = 0; i < octets.length; i++) {
+      if (parseInt(octets[i], 10) > 255) return ""
+    }
+    return text
+  }
+
+  // IPv6 has too many legal spellings to re-implement here, so this checks the
+  // alphabet and the shape rather than the grouping.
+  if (/^[0-9a-fA-F:]+$/.test(text) && text.indexOf("::") === text.lastIndexOf("::")) {
+    if (text.indexOf(":") !== -1 && !/:::/.test(text)) return text.toLowerCase()
+  }
+  return ""
+}
+
 function elide(text, limit) {
   var value = String(text || "").replace(/\s+/g, " ").trim()
   return value.length > limit ? value.substring(0, limit - 1) + "…" : value
@@ -351,9 +378,10 @@ function unescapeNmcli(value) {
 }
 
 // Generated on the fly for a device someone else brought up, rather than a
-// profile on disk. An older nmcli that does not report FILENAME leaves this
-// empty, in which case the connection is kept — better a stray row than a
-// backend that lists nothing at all.
+// profile on disk. Empty means the field was never asked for: nmcli refuses a
+// listing that names a field it does not know, so an nmcli too old for
+// FILENAME is retried without it — see NetworkManagerBackend. Such a
+// connection is kept, since a stray row beats a backend that lists nothing.
 function isVolatileConnection(filename) {
   return String(filename || "").indexOf("/run/") === 0
 }
@@ -745,8 +773,14 @@ function mullvadCurrentKey(status, countries) {
 //   Autoconnect: off
 //   Block traffic when the VPN is disconnected: off
 //   Local network sharing setting: block
+//
+// One shell means one exit code — the last subcommand's — so a subcommand that
+// failed or that this version of the CLI does not have leaves no line and no
+// error. `seen` is which answers actually arrived: an unanswered setting is
+// unknown, not off. Reporting lockdown mode as off while it is on is the one
+// mistake a VPN widget must not make.
 function parseMullvadSettings(raw) {
-  var settings = { autoconnect: false, lockdown: false, lan: false, loaded: false }
+  var settings = { autoconnect: false, lockdown: false, lan: false, seen: {}, loaded: false }
   var lines = String(raw || "").split("\n")
 
   for (var i = 0; i < lines.length; i++) {
@@ -760,26 +794,39 @@ function parseMullvadSettings(raw) {
 
     if (key === "autoconnect") {
       settings.autoconnect = value === "on"
-      settings.loaded = true
+      settings.seen.autoconnect = true
     } else if (key.indexOf("block traffic") === 0) {
       settings.lockdown = value === "on"
-      settings.loaded = true
+      settings.seen.lockdown = true
     } else if (key.indexOf("local network sharing") === 0) {
       settings.lan = value === "allow"
-      settings.loaded = true
+      settings.seen.lan = true
     }
   }
+
+  settings.loaded = settings.seen.autoconnect === true
+    || settings.seen.lockdown === true
+    || settings.seen.lan === true
   return settings
 }
 
+// A switch is drawn only for a setting the daemon answered for. A partial read
+// shows fewer switches rather than a full row of confident wrong ones.
 function mullvadToggles(settings) {
   if (!settings || !settings.loaded) return []
 
-  return [
-    toggle("autoconnect", "Connect on startup", "Up as soon as the daemon starts", settings.autoconnect),
-    toggle("lockdown", "Lockdown mode", "No traffic at all while down", settings.lockdown),
-    toggle("lan", "Allow local network", "Reach printers and NAS while up", settings.lan)
-  ]
+  var seen = settings.seen || {}
+  var toggles = []
+  if (seen.autoconnect === true) {
+    toggles.push(toggle("autoconnect", "Connect on startup", "Up as soon as the daemon starts", settings.autoconnect))
+  }
+  if (seen.lockdown === true) {
+    toggles.push(toggle("lockdown", "Lockdown mode", "No traffic at all while down", settings.lockdown))
+  }
+  if (seen.lan === true) {
+    toggles.push(toggle("lan", "Allow local network", "Reach printers and NAS while up", settings.lan))
+  }
+  return toggles
 }
 
 function mullvadToggleArgs(key, value) {

--- a/Model.js
+++ b/Model.js
@@ -11,6 +11,7 @@ var GLYPH_SWAP = String.fromCodePoint(0xF04E1)
 var GLYPH_SHIELD = String.fromCodePoint(0xF0498)
 var GLYPH_CHEVRON_DOWN = String.fromCodePoint(0xF0140)
 var GLYPH_CHEVRON_UP = String.fromCodePoint(0xF0143)
+var GLYPH_COG = String.fromCodePoint(0xF0493)
 
 // ----------------------------------------------------------------- shared
 
@@ -37,6 +38,36 @@ function applyPendingToggles(toggles, pending) {
     if (pending[entry.key] === undefined) return entry
     return { key: entry.key, label: entry.label, detail: entry.detail, value: pending[entry.key] === true, busy: true }
   })
+}
+
+// --------------------------------------------------------- widget settings
+
+// Which tools the user told the widget to ignore, stored as one comma-separated
+// string so the setting stays hand-editable in shell.json and in Omarchy's own
+// settings dialog, which has no array field.
+function parseBackendIds(raw) {
+  var ids = []
+  var parts = String(raw || "").split(",")
+  for (var i = 0; i < parts.length; i++) {
+    var id = parts[i].trim().toLowerCase()
+    if (id !== "" && ids.indexOf(id) === -1) ids.push(id)
+  }
+  return ids
+}
+
+function joinBackendIds(ids) {
+  return ids.join(",")
+}
+
+function toggleBackendId(ids, id) {
+  var next = []
+  var found = false
+  for (var i = 0; i < ids.length; i++) {
+    if (ids[i] === id) found = true
+    else next.push(ids[i])
+  }
+  if (!found) next.push(id)
+  return next
 }
 
 // ------------------------------------------------------------ Proton VPN

--- a/MullvadBackend.qml
+++ b/MullvadBackend.qml
@@ -30,8 +30,12 @@ Item {
   property string lastError: ""
 
   // The stored "block traffic while disconnected" setting, which the status
-  // payload only reports while the tunnel is already down.
-  readonly property bool lockdownMode: daemonSettings.lockdown
+  // payload only reports while the tunnel is already down. False also covers
+  // "the daemon never answered for it" — see parseMullvadSettings — so this
+  // drives a warning and never a switch position.
+  readonly property bool lockdownMode: daemonSettings.seen !== undefined
+    && daemonSettings.seen.lockdown === true
+    && daemonSettings.lockdown
 
   // Switches the panel draws under the detail rows. Values are whatever the
   // daemon last reported; the widget stores none of them.
@@ -67,8 +71,13 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
-  function detect() {
+  // Asked once. `force` is the user asking again, which is the only time the
+  // answer could have changed — see refreshAll() in VpnController.
+  property bool _probed: false
+
+  function detect(force) {
     if (detectProcess.running) return
+    if (_probed && force !== true) return
     detectProcess.running = true
   }
 
@@ -94,18 +103,23 @@ Item {
     _toggleKey = key
     toggleProcess.command = ["mullvad"].concat(args)
     toggleProcess.running = true
+    pendingTimer.restart()
   }
 
   function applySettings(raw) {
     var parsed = Model.parseMullvadSettings(raw)
+    // A read that answered nothing is not a report that everything is off.
+    // Keep whatever the daemon last actually said.
+    if (!parsed.loaded) return
     root.daemonSettings = parsed
 
     // Drop the optimistic value only for the switches the daemon now agrees
-    // with, so a poll landing mid-flight cannot flick the others back.
+    // with, so a poll landing mid-flight cannot flick the others back. A
+    // setting the daemon did not answer for agrees with nothing.
     var pending = {}
     var changed = false
     for (var key in _pendingToggles) {
-      if (parsed[key] === _pendingToggles[key]) changed = true
+      if (parsed.seen[key] === true && parsed[key] === _pendingToggles[key]) changed = true
       else pending[key] = _pendingToggles[key]
     }
     if (changed) _pendingToggles = pending
@@ -187,6 +201,22 @@ Item {
     return "The Mullvad daemon is not responding. Start it with: sudo systemctl start mullvad-daemon"
   }
 
+  // A command that exits clean but does not take — the daemon accepts it and
+  // then reports the old value — would otherwise leave the switch showing the
+  // position the user asked for, marked busy, for as long as the panel is open.
+  // Optimism gets a deadline: past it, the switches go back to what the daemon
+  // actually says, which is the whole point of not storing them here.
+  Timer {
+    id: pendingTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (Object.keys(root._pendingToggles).length === 0) return
+      root._pendingToggles = ({})
+      root.lastError = "Mullvad did not apply that setting."
+    }
+  }
+
   // The daemon reports the new state a beat after the command returns, and a
   // WireGuard handshake over a slow link can take a few seconds more than
   // Proton's CLI does, so poll a little longer than that backend.
@@ -228,6 +258,7 @@ Item {
     command: ["omarchy-cmd-present", "mullvad"]
     running: true
     onExited: function(exitCode) {
+      root._probed = true
       root.detected = exitCode === 0
       if (root.detected) root.refresh()
     }
@@ -257,13 +288,16 @@ Item {
 
   // Three subcommands, one process. Each answer names itself, so the parser
   // does not care about the order they come back in.
+  //
+  // The exit code belongs to the last subcommand alone and says nothing about
+  // the other two, so it is not consulted: the parser reads whichever answers
+  // arrived and reports the rest as unanswered rather than as off.
   Process {
     id: settingsProcess
     running: false
     command: ["bash", "-c", "mullvad auto-connect get; mullvad lockdown-mode get; mullvad lan get"]
     stdout: StdioCollector { id: settingsStdout; waitForEnd: true }
     onExited: function(exitCode) {
-      if (exitCode !== 0) return
       root.applySettings(String(settingsStdout.text || ""))
     }
   }
@@ -286,6 +320,10 @@ Item {
     }
   }
 
+  // `relay list` is the largest thing this CLI prints, so "loaded" has to mean
+  // "asked and answered", not "answered with something". Keying it off the
+  // parsed count made a format change re-fetch the whole list on every poll,
+  // forever, while the panel showed no countries and no reason why.
   Process {
     id: relaysProcess
     running: false
@@ -294,7 +332,10 @@ Item {
     onExited: function(exitCode) {
       if (exitCode !== 0) return
       root.relays = Model.parseMullvadRelays(String(relaysStdout.text || ""))
-      root.relaysLoaded = root.relays.length > 0
+      root.relaysLoaded = true
+      if (root.relays.length === 0) {
+        root.lastError = "Could not read the relay list. Check: mullvad relay list"
+      }
     }
   }
 

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -19,7 +19,6 @@ Item {
   readonly property bool supportsFilter: false
   readonly property string filterPlaceholder: ""
 
-  property bool detected: false
   property var profiles: []
   property string actionStatus: ""
   property string lastError: ""
@@ -29,6 +28,18 @@ Item {
   // gets the chip, and a profile of a kind you cannot run simply never appears.
   property bool _openvpnPresent: false
   property bool _wireguardPresent: false
+  property int _probesDone: 0
+  property bool _probed: false
+
+  readonly property bool _toolsPresent: _nmcliPresent && (_openvpnPresent || _wireguardPresent)
+  // Having the tools is not having anything to connect to. NetworkManager is
+  // the one backend whose list can be legitimately empty on a working install,
+  // and a chip leading to an empty list is a chip worth not drawing.
+  readonly property bool detected: _toolsPresent && profiles.length > 0
+
+  // Said instead of the panel's "install a VPN tool" line, which is unhelpful
+  // advice for someone who has the tools and only lacks a profile.
+  readonly property string setupHint: _toolsPresent && profiles.length === 0 ? emptyText : ""
   property int _desired: -1
   property var _pendingTarget: null
   // Connecting can take two commands — down the profile that is up, then up the
@@ -59,20 +70,30 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
+  // `detected` now depends on the profile list, so the controller keeps calling
+  // detect() on a machine that has the tools and no profiles. The binaries do
+  // not come and go; once probed, this is a plain refresh rather than three
+  // more processes every poll.
   function detect() {
+    if (_probed) {
+      refresh()
+      return
+    }
     if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
   }
 
-  function _updateDetected() {
-    root.detected = _nmcliPresent && (_openvpnPresent || _wireguardPresent)
-    if (root.detected) root.refresh()
+  function _probeFinished() {
+    root._probesDone += 1
+    if (root._probesDone < 3) return
+    root._probed = true
+    if (root._toolsPresent) root.refresh()
   }
 
   function refresh() {
-    if (!detected || listProcess.running) return
+    if (!_toolsPresent || listProcess.running) return
     listProcess.running = true
   }
 
@@ -150,9 +171,20 @@ Item {
     actionStatusTimer.restart()
   }
 
+  // A profile is only eligible if the tool that carries its kind is installed:
+  // NetworkManager lists an OpenVPN profile whether or not anything can run it.
+  function runnable(profile) {
+    return profile.kind === "wireguard" ? _wireguardPresent : _openvpnPresent
+  }
+
   function applyProfiles(list) {
-    root.profiles = list
-    if (_desired !== -1 && (Model.activeNmProfile(list) !== null) === (_desired === 1)) _desired = -1
+    var eligible = []
+    for (var i = 0; i < list.length; i++) {
+      if (runnable(list[i])) eligible.push(list[i])
+    }
+
+    root.profiles = eligible
+    if (_desired !== -1 && (Model.activeNmProfile(eligible) !== null) === (_desired === 1)) _desired = -1
   }
 
   Timer {
@@ -195,7 +227,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._nmcliPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 
@@ -205,7 +237,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._openvpnPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 
@@ -218,7 +250,7 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._wireguardPresent = exitCode === 0
-      root._updateDetected()
+      root._probeFinished()
     }
   }
 

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -70,16 +70,15 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
-  // `detected` now depends on the profile list, so the controller keeps calling
-  // detect() on a machine that has the tools and no profiles. The binaries do
-  // not come and go; once probed, this is a plain refresh rather than three
-  // more processes every poll.
+  // Probing only. `detected` depends on the profile list, so the controller
+  // keeps calling this on a machine that has the tools and no profiles — but
+  // the discovery that would settle that question belongs in refresh(), which
+  // the controller skips for a hidden tool. Falling through to it here would
+  // poll a tool the user switched off. The binaries do not come and go, so once
+  // probed this is nothing rather than three more processes every poll.
   function detect(force) {
     if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
-    if (_probed && force !== true) {
-      refresh()
-      return
-    }
+    if (_probed && force !== true) return
     _probesDone = 0
     nmcliProbe.running = true
     openvpnProbe.running = true

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -74,12 +74,13 @@ Item {
   // detect() on a machine that has the tools and no profiles. The binaries do
   // not come and go; once probed, this is a plain refresh rather than three
   // more processes every poll.
-  function detect() {
-    if (_probed) {
+  function detect(force) {
+    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
+    if (_probed && force !== true) {
       refresh()
       return
     }
-    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
+    _probesDone = 0
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
@@ -92,8 +93,11 @@ Item {
     if (root._toolsPresent) root.refresh()
   }
 
+  // The two passes share `listProcess.pending`, so a refresh landing while the
+  // second one is still out would hand it a list the details it is holding do
+  // not describe. One discovery at a time.
   function refresh() {
-    if (!_toolsPresent || listProcess.running) return
+    if (!_toolsPresent || listProcess.running || typesProcess.running) return
     listProcess.running = true
   }
 
@@ -254,19 +258,48 @@ Item {
     }
   }
 
+  // nmcli rejects the whole call when asked for a field it does not know, so an
+  // nmcli too old for FILENAME does not return rows without it — it returns
+  // nothing at all, and the backend would silently never appear. The first
+  // refusal drops the field and the list is fetched again; volatile-connection
+  // filtering is what is lost, which is a stray row rather than no backend.
+  property bool _filenameField: true
+  readonly property var _listCommand: _filenameField
+    ? ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE,FILENAME", "connection", "show"]
+    : ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE", "connection", "show"]
+
+  function unknownField(text) {
+    return /not among|unknown field|invalid field|allowed fields/i.test(String(text || ""))
+  }
+
+  // Retrying from inside onExited would re-enter the process that is still
+  // finishing, the same reason the connect chain hops through the event loop.
+  Timer {
+    id: listRetry
+    interval: 0
+    repeat: false
+    onTriggered: root.refresh()
+  }
+
   // Every tunnel-shaped connection: `vpn` whichever plugin backs it, plus
   // `wireguard`, which NetworkManager types as its own thing rather than as a
   // VPN plugin.
   Process {
     id: listProcess
     running: false
-    command: ["nmcli", "-t", "-f", "NAME,UUID,TYPE,ACTIVE,FILENAME", "connection", "show"]
+    command: root._listCommand
     stdout: StdioCollector { id: listStdout; waitForEnd: true }
     stderr: StdioCollector { id: listStderr; waitForEnd: true }
     property var pending: []
     onExited: function(exitCode) {
       if (exitCode !== 0) {
-        root.lastError = Model.elide(String(listStderr.text || "") || "Could not list NetworkManager connections", 140)
+        var failure = String(listStderr.text || "")
+        if (root._filenameField && root.unknownField(failure)) {
+          root._filenameField = false
+          listRetry.restart()
+          return
+        }
+        root.lastError = Model.elide(failure || "Could not list NetworkManager connections", 140)
         return
       }
 
@@ -304,9 +337,16 @@ Item {
     running: false
     command: []
     stdout: StdioCollector { id: typesStdout; waitForEnd: true }
+    stderr: StdioCollector { id: typesStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      // One profile deleted between the two passes fails the whole call. That
+      // is a reason to keep the list from last time, not to declare the machine
+      // has no tunnels: emptying it here drops `detected`, takes the chip away
+      // while a tunnel is up, and with it the only way to bring that tunnel
+      // down — disconnect() refuses to run undetected.
       if (exitCode !== 0) {
-        root.applyProfiles([])
+        root.lastError = Model.elide(
+          String(typesStderr.text || "") || "Could not read NetworkManager profile details", 140)
         return
       }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -60,8 +60,14 @@ Panel {
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
   readonly property bool gearHasCursor: headerHasCursor && headerIndex === 0
   readonly property bool switchHasCursor: headerHasCursor && headerIndex === 1
+  // The controller's notice outranks the backend's own line: it says why the
+  // connect now under way cannot land, which is worth more than watching it
+  // report that it is under way.
+  readonly property bool statusIsError: vpn.notice !== ""
+    || (backend !== null && backend.lastError !== "" && backend.actionStatus === "")
   readonly property string statusLine: {
     if (providersOpen) return ""
+    if (vpn.notice !== "") return vpn.notice
     if (!backend) {
       if (vpn.detectedBackends.length > 0) return "Every VPN tool is hidden. Turn one back on with the gear."
       return vpn.setupHint !== ""
@@ -157,7 +163,13 @@ Panel {
     selectBackend(options[next].backendId)
   }
 
+  // The filter field belongs to the panel, not to the tool, so it does not
+  // travel with the chip. Both ends are cleared on the way across: the outgoing
+  // tool would otherwise keep a filter nothing is showing, and the field would
+  // sit there full of text the incoming list is not filtered by.
   function selectBackend(backendId) {
+    if (root.backend) root.backend.filter = ""
+    filterField.text = ""
     vpn.selectBackend(backendId)
     rowIndex = 0
     toggleIndex = 0
@@ -241,6 +253,7 @@ Panel {
     providersOpen = !providersOpen
     rowIndex = 0
     toggleIndex = 0
+    if (backend) backend.filter = ""
     filterField.text = ""
     setHeaderCursor(0)
   }
@@ -332,9 +345,12 @@ Panel {
     // open the panel to connect, not to reconsider which tools exist.
     providersOpen = false
     focusSection = "rows"
+    if (backend) backend.filter = ""
     filterField.text = ""
     if (panelFlick) panelFlick.contentY = 0
-    vpn.refreshAll()
+    // Opening the panel re-probes for tools installed since the shell started;
+    // the background poll deliberately does not.
+    vpn.refreshAll(true)
     // The address is fetched on connection changes, not on a timer, so a first
     // open with nothing cached is the one other moment worth asking.
     if (vpn.publicIp === "") vpn.refreshPublicIp()
@@ -373,7 +389,7 @@ Panel {
     function show(): void { root.open() }
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
-    function refresh(): string { vpn.refreshAll(); vpn.refreshPublicIp(); return "ok" }
+    function refresh(): string { vpn.refreshAll(true); vpn.refreshPublicIp(); return "ok" }
     function status(): string { return vpn.barSummary }
     function ip(): string { return vpn.publicIp !== "" ? vpn.publicIp : "unknown" }
     function backends(): string {
@@ -424,7 +440,7 @@ Panel {
     tooltipText: "VPN: " + vpn.barSummary
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) vpn.toggleActive()
-      else if (buttonCode === Qt.MiddleButton) { vpn.refreshAll(); vpn.refreshPublicIp() }
+      else if (buttonCode === Qt.MiddleButton) { vpn.refreshAll(true); vpn.refreshPublicIp() }
       else root.toggle()
     }
   }
@@ -455,7 +471,7 @@ Panel {
       onTextKey: function(t) {
         if (t === "/" && root.filterVisible) filterField.forceActiveFocus()
         else if (t === "d" || t === "D") { if (root.backend) root.backend.disconnect() }
-        else if (t === "r" || t === "R") { vpn.refreshAll(); vpn.refreshPublicIp() }
+        else if (t === "r" || t === "R") { vpn.refreshAll(true); vpn.refreshPublicIp() }
         else if (t === "s" || t === "S") { if (root.switcherVisible) root.stepBackend(1) }
       }
 
@@ -556,7 +572,11 @@ Panel {
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
               visible: root.masterSwitchVisible
-              checked: vpn.anyConnected
+              // The tool being looked at, not "anything at all". Flipping this
+              // calls toggleActive(), which acts on the selected backend — a
+              // switch reading "on" because a *different* tool is connected
+              // would take that tunnel down and bring this one up instead.
+              checked: root.backend ? root.backend.connected : false
               busy: root.backend ? root.backend.busy : false
               hasCursor: root.switchHasCursor
               foreground: root.foreground
@@ -565,7 +585,7 @@ Panel {
 
               PanelToolTip {
                 visible: masterSwitch.containsMouse
-                text: vpn.anyConnected ? "Disconnect" : "Connect"
+                text: masterSwitch.checked ? "Disconnect" : "Connect"
                 fontFamily: root.fontFamily
               }
             }
@@ -651,7 +671,7 @@ Panel {
             visible: root.statusLine !== ""
             width: parent.width
             text: root.statusLine
-            color: root.backend && root.backend.lastError !== "" && root.backend.actionStatus === "" ? root.urgent : root.dim
+            color: root.statusIsError ? root.urgent : root.dim
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
             wrapMode: Text.WordWrap

--- a/Panel.qml
+++ b/Panel.qml
@@ -406,10 +406,15 @@ Panel {
         vpn.toggleActive()
         return "ok"
       }
+      // A bare country code is the documented shorthand, and it is the row key
+      // that spells it the same way for every backend: the detail line does
+      // not — Mullvad's carries a city count after the code.
+      var byCode = "country:" + wanted.toUpperCase()
       var targets = vpn.active.targets
       for (var i = 0; i < targets.length; i++) {
         var candidate = targets[i]
-        if (candidate.key === wanted || candidate.detail === wanted || candidate.label === wanted) {
+        if (candidate.key === wanted || candidate.key === byCode
+            || candidate.detail === wanted || candidate.label === wanted) {
           vpn.connectVia(vpn.active, candidate)
           return "ok"
         }
@@ -418,7 +423,7 @@ Panel {
     }
     function disconnect(): string {
       if (!vpn.active) return "no backend"
-      vpn.active.disconnect()
+      vpn.disconnectActive()
       return "ok"
     }
     // A declared IPC argument is mandatory, so "connect, no target in mind"
@@ -470,7 +475,10 @@ Panel {
       // swallowing plain letters.
       onTextKey: function(t) {
         if (t === "/" && root.filterVisible) filterField.forceActiveFocus()
-        else if (t === "d" || t === "D") { if (root.backend) root.backend.disconnect() }
+        // Through the controller, for the same reason connecting is: it is the
+        // one that knows about a connect still queued behind a teardown, which
+        // is exactly what pressing this is asking to call off.
+        else if (t === "d" || t === "D") vpn.disconnectActive()
         else if (t === "r" || t === "R") { vpn.refreshAll(true); vpn.refreshPublicIp() }
         else if (t === "s" || t === "S") { if (root.switcherVisible) root.stepBackend(1) }
       }

--- a/Panel.qml
+++ b/Panel.qml
@@ -17,6 +17,12 @@ Panel {
   property string focusSection: "rows"
   property int rowIndex: 0
   property int toggleIndex: 0
+  // Inside the header: 0 is the gear, 1 the master switch.
+  property int headerIndex: 1
+  // The widget's own settings, as opposed to the tool's. They replace the body
+  // rather than fold out below it: nothing in the connect list means anything
+  // while you are deciding which tools the widget should know about.
+  property bool providersOpen: false
   // Settings start folded away: they are the part of the panel you touch once
   // and then leave alone. Kept for the session, not per open.
   property bool settingsExpanded: false
@@ -29,17 +35,39 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   readonly property var backend: vpn.active
-  readonly property var rows: backend ? backend.targets : []
+  // One tool per row, switch on the right: the whole widget setting is which
+  // of the tools on this machine it should bother with.
+  readonly property var providerRows: vpn.detectedBackends.map(function(entry) {
+    var hidden = vpn.isHidden(entry.backendId)
+    return {
+      key: "provider:" + entry.backendId,
+      backendId: entry.backendId,
+      label: entry.label,
+      detail: hidden ? "Hidden" : (entry.connected ? "Connected" : "Shown"),
+      glyph: entry.glyph,
+      hidden: hidden
+    }
+  })
+  readonly property var rows: providersOpen ? providerRows : (backend ? backend.targets : [])
   // Tool settings, for the backends that have any. A backend without them
   // simply has no block here.
   readonly property var toggles: backend && backend.toggles ? backend.toggles : []
-  readonly property bool settingsAvailable: toggles.length > 0
+  readonly property bool settingsAvailable: !providersOpen && toggles.length > 0
   readonly property bool settingsVisible: settingsAvailable && settingsExpanded
-  readonly property bool switcherVisible: vpn.availableBackends.length > 1
-  readonly property bool filterVisible: backend !== null && backend.supportsFilter
+  readonly property bool switcherVisible: !providersOpen && vpn.availableBackends.length > 1
+  readonly property bool filterVisible: !providersOpen && backend !== null && backend.supportsFilter
+  readonly property bool masterSwitchVisible: backend !== null
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
+  readonly property bool gearHasCursor: headerHasCursor && headerIndex === 0
+  readonly property bool switchHasCursor: headerHasCursor && headerIndex === 1
   readonly property string statusLine: {
-    if (!backend) return "Install Proton VPN, Mullvad, OpenVPN, or WireGuard to use this widget."
+    if (providersOpen) return ""
+    if (!backend) {
+      if (vpn.detectedBackends.length > 0) return "Every VPN tool is hidden. Turn one back on with the gear."
+      return vpn.setupHint !== ""
+        ? vpn.setupHint
+        : "Install Proton VPN, Mullvad, OpenVPN, or WireGuard to use this widget."
+    }
     return backend.actionStatus !== "" ? backend.actionStatus : backend.lastError
   }
 
@@ -47,6 +75,13 @@ Panel {
     if (rows.length === 0 && focusSection === "rows") focusSection = "header"
     if (!settingsAvailable && focusSection === "hero") focusSection = "header"
     if (!settingsVisible && focusSection === "toggles") focusSection = settingsAvailable ? "hero" : "header"
+    if (!switcherVisible && focusSection === "switcher") focusSection = "header"
+    // The master switch is gone without a backend, so the gear is all the
+    // header has left — and it is the way back from a widget with everything
+    // hidden, which is exactly when that happens.
+    if (!masterSwitchVisible) headerIndex = 0
+    if (headerIndex < 0) headerIndex = 0
+    if (headerIndex > 1) headerIndex = 1
     if (rowIndex >= rows.length) rowIndex = Math.max(0, rows.length - 1)
     if (rowIndex < 0) rowIndex = 0
     if (toggleIndex >= toggles.length) toggleIndex = Math.max(0, toggles.length - 1)
@@ -59,6 +94,7 @@ Panel {
 
     if (dx !== 0) {
       if (focusSection === "switcher") stepBackend(dx)
+      else if (focusSection === "header") stepHeader(dx)
       return
     }
     if (dy === 0) return
@@ -134,10 +170,17 @@ Panel {
     if (panelFlick) panelFlick.contentY = 0
   }
 
-  function setHeaderCursor() {
+  function setHeaderCursor(index) {
     cursorActive = true
     focusSection = "header"
+    if (index !== undefined) headerIndex = index
+    if (!masterSwitchVisible) headerIndex = 0
     if (panelFlick) panelFlick.contentY = 0
+  }
+
+  function stepHeader(direction) {
+    if (!masterSwitchVisible) return
+    headerIndex = Math.max(0, Math.min(1, headerIndex + direction))
   }
 
   function setRowCursor(index) {
@@ -174,13 +217,52 @@ Panel {
     else if (settingsExpanded) setHeroCursor()
   }
 
+  // The gear and the provider rows work without a backend — they are how you
+  // get one back — so they are checked before the "nothing detected" bail.
   function activateCursor() {
     ensureCursor()
+    if (focusSection === "header") {
+      if (headerIndex === 0) toggleProviders()
+      else if (backend) vpn.toggleActive()
+      return
+    }
+    if (focusSection === "rows" && rows.length > 0) {
+      activateRow(rows[rowIndex])
+      return
+    }
     if (!backend) return
-    if (focusSection === "header") vpn.toggleActive()
-    else if (focusSection === "hero") toggleSettings()
+    if (focusSection === "hero") toggleSettings()
     else if (focusSection === "toggles" && toggles.length > 0) flipToggle(toggleIndex)
-    else if (focusSection === "rows" && rows.length > 0) activateRow(rows[rowIndex])
+  }
+
+  // A view, not a drawer: the cursor stays on the gear that opened it, which is
+  // also the way out.
+  function toggleProviders() {
+    providersOpen = !providersOpen
+    rowIndex = 0
+    toggleIndex = 0
+    filterField.text = ""
+    setHeaderCursor(0)
+  }
+
+  function toggleProvider(row) {
+    if (!row || row.backendId === undefined) return
+    var next = Model.toggleBackendId(vpn.hiddenBackendIds, row.backendId)
+    saveSetting("hiddenBackends", Model.joinBackendIds(next))
+  }
+
+  // Widget settings live in this widget's shell.json entry, the same place the
+  // Omarchy settings dialog writes them, so the two agree on the next reload.
+  function saveSetting(key, value) {
+    var next = {}
+    for (var name in settings) {
+      if (name !== "id") next[name] = settings[name]
+    }
+    next[key] = value
+    root.settings = next
+    if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
+      bar.shell.updateEntryInline(root.moduleName, next)
+    }
   }
 
   // Settings go straight to the backend: they change how the tool behaves, not
@@ -199,7 +281,12 @@ Panel {
   }
 
   function activateRow(row) {
-    if (!backend || !row) return
+    if (!row) return
+    if (providersOpen) {
+      toggleProvider(row)
+      return
+    }
+    if (!backend) return
     // Through the controller, never straight to the backend: picking a tunnel
     // means the others come down first.
     vpn.connectVia(backend, row)
@@ -240,6 +327,10 @@ Panel {
     cursorActive = false
     rowIndex = 0
     toggleIndex = 0
+    headerIndex = 1
+    // The tool settings stay however you left them; this view does not. You
+    // open the panel to connect, not to reconsider which tools exist.
+    providersOpen = false
     focusSection = "rows"
     filterField.text = ""
     if (panelFlick) panelFlick.contentY = 0
@@ -385,20 +476,23 @@ Panel {
           spacing: Style.space(12)
 
           // Status bar for the whole widget: where traffic is coming out on the
-          // left, the one master switch on the right. Both sit above the
-          // backend chips because they describe the connection, not the tool.
+          // left, the gear and the one master switch on the right. All of it
+          // sits above the backend chips because it describes the connection
+          // and the widget, not whichever tool is being looked at.
           Item {
             id: header
             width: parent.width
-            implicitHeight: Math.max(ipLabel.implicitHeight, masterSwitch.implicitHeight)
-            readonly property bool ringVisible: root.headerHasCursor
-            function focusHeader() { root.setHeaderCursor() }
+            implicitHeight: Math.max(ipLabel.implicitHeight,
+              Math.max(gearButton.implicitHeight, masterSwitch.implicitHeight))
+            readonly property real controlsWidth: gearButton.width
+              + (masterSwitch.visible ? masterSwitch.width + Style.space(8) : 0)
+              + Style.space(12)
 
             Item {
               id: ipLabel
               anchors.left: parent.left
               anchors.verticalCenter: parent.verticalCenter
-              width: Math.min(ipRow.implicitWidth, parent.width - masterSwitch.width - Style.space(12))
+              width: Math.min(ipRow.implicitWidth, parent.width - header.controlsWidth)
               height: ipRow.implicitHeight
 
               // Only an address is worth copying; a placeholder is not.
@@ -443,16 +537,30 @@ Panel {
               }
             }
 
+            PanelActionButton {
+              id: gearButton
+              anchors.right: masterSwitch.visible ? masterSwitch.left : parent.right
+              anchors.rightMargin: masterSwitch.visible ? Style.space(8) : 0
+              anchors.verticalCenter: parent.verticalCenter
+              iconText: Model.GLYPH_COG
+              tooltipText: root.providersOpen ? "Back" : "Widget settings"
+              hasCursor: root.gearHasCursor
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              onHovered: function(on) { if (on) root.setHeaderCursor(0) }
+              onClicked: root.toggleProviders()
+            }
+
             ToggleSwitch {
               id: masterSwitch
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
-              visible: root.backend !== null
+              visible: root.masterSwitchVisible
               checked: vpn.anyConnected
               busy: root.backend ? root.backend.busy : false
-              hasCursor: header.ringVisible
+              hasCursor: root.switchHasCursor
               foreground: root.foreground
-              onHovered: function(on) { if (on) header.focusHeader() }
+              onHovered: function(on) { if (on) root.setHeaderCursor(1) }
               onToggled: vpn.toggleActive()
 
               PanelToolTip {
@@ -486,6 +594,7 @@ Panel {
           // the hero exactly as it was.
           CursorSurface {
             id: heroSurface
+            visible: !root.providersOpen
             width: parent.width
             implicitHeight: hero.implicitHeight + Style.spacing.rowPaddingX
             hasCursor: root.cursorActive && root.focusSection === "hero"
@@ -549,7 +658,7 @@ Panel {
           }
 
           Column {
-            visible: root.backend !== null && root.backend.details.length > 0
+            visible: !root.providersOpen && root.backend !== null && root.backend.details.length > 0
             width: parent.width
             spacing: Style.spacing.labelGap
 
@@ -589,7 +698,7 @@ Panel {
           }
 
           PanelSeparator {
-            visible: root.backend !== null
+            visible: root.providersOpen || root.backend !== null
             foreground: root.foreground
           }
 
@@ -615,12 +724,15 @@ Panel {
           }
 
           Column {
-            visible: root.backend !== null
+            visible: root.providersOpen || root.backend !== null
             width: parent.width
             spacing: Style.space(10)
 
             PanelSectionHeader {
-              text: root.filterVisible && root.backend && root.backend.filter !== "" ? "MATCHING" : "CONNECT"
+              text: {
+                if (root.providersOpen) return "PROVIDERS"
+                return root.filterVisible && root.backend && root.backend.filter !== "" ? "MATCHING" : "CONNECT"
+              }
               foreground: root.foreground
               fontFamily: root.fontFamily
             }
@@ -628,7 +740,10 @@ Panel {
             Text {
               visible: root.rows.length === 0
               width: parent.width
-              text: root.backend ? root.backend.emptyText : ""
+              text: {
+                if (root.providersOpen) return "No VPN tool detected on this machine."
+                return root.backend ? root.backend.emptyText : ""
+              }
               color: root.dim
               font.family: root.fontFamily
               font.pixelSize: Style.font.bodySmall
@@ -662,7 +777,13 @@ Panel {
     id: targetRow
     property var row: null
     property int cursorIndex: 0
-    readonly property bool isCurrent: root.backend !== null
+    // A provider row is the same row with a switch where the check mark goes:
+    // it says whether the widget uses that tool, not whether it is connected.
+    readonly property bool isProvider: row !== null && row.hidden !== undefined
+    // A hidden tool reads as switched off rather than as a row you could pick.
+    readonly property bool rowMuted: isProvider && row.hidden === true
+    readonly property bool isCurrent: !isProvider
+      && root.backend !== null
       && row
       && row.key === root.backend.currentKey
 
@@ -690,7 +811,7 @@ Panel {
 
       Text {
         text: targetRow.row ? targetRow.row.glyph : ""
-        color: root.foreground
+        color: targetRow.rowMuted ? root.dim : root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.icon
         Layout.alignment: Qt.AlignVCenter
@@ -704,7 +825,7 @@ Panel {
         Text {
           Layout.fillWidth: true
           text: targetRow.row ? targetRow.row.label : ""
-          color: root.foreground
+          color: targetRow.rowMuted ? root.dim : root.foreground
           font.family: root.fontFamily
           font.pixelSize: Style.font.body
           elide: Text.ElideRight
@@ -727,6 +848,17 @@ Panel {
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.icon
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ToggleSwitch {
+        visible: targetRow.isProvider
+        checked: targetRow.isProvider && !targetRow.row.hidden
+        foreground: root.foreground
+        // Same reason the tool settings do it: the row owns the click and the
+        // cursor ring, so a switch that owned them too would read as a second
+        // target inside the first.
+        interactive: false
         Layout.alignment: Qt.AlignVCenter
       }
     }

--- a/ProtonBackend.qml
+++ b/ProtonBackend.qml
@@ -60,8 +60,13 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
-  function detect() {
+  // Asked once. `force` is the user asking again, which is the only time the
+  // answer could have changed — see refreshAll() in VpnController.
+  property bool _probed: false
+
+  function detect(force) {
     if (detectProcess.running) return
+    if (_probed && force !== true) return
     detectProcess.running = true
   }
 
@@ -87,6 +92,7 @@ Item {
     _toggleKey = key
     toggleProcess.command = ["protonvpn"].concat(args)
     toggleProcess.running = true
+    pendingTimer.restart()
   }
 
   function applyConfig(raw) {
@@ -150,6 +156,22 @@ Item {
     if (_desired !== -1 && parsed.connected === (_desired === 1)) _desired = -1
   }
 
+  // A command that exits clean but does not take — the CLI accepts it and then
+  // lists the old value — would otherwise leave the switch showing the position
+  // the user asked for, marked busy, for as long as the panel is open. Optimism
+  // gets a deadline: past it, the switches go back to what the CLI actually
+  // says, which is the whole point of not storing them here.
+  Timer {
+    id: pendingTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (Object.keys(root._pendingToggles).length === 0) return
+      root._pendingToggles = ({})
+      root.lastError = "Proton VPN did not apply that setting."
+    }
+  }
+
   // The CLI reports the new state a beat after the command returns, so re-poll
   // a few times instead of waiting out the controller's refresh interval.
   Timer {
@@ -174,6 +196,7 @@ Item {
     command: ["omarchy-cmd-present", "protonvpn"]
     running: true
     onExited: function(exitCode) {
+      root._probed = true
       root.detected = exitCode === 0
       if (root.detected) root.refresh()
     }
@@ -243,6 +266,9 @@ Item {
     }
   }
 
+  // "Loaded" means asked and answered. A table this parser cannot read is a
+  // reason to say so once, not to re-fetch the list on every poll for as long
+  // as the shell runs.
   Process {
     id: countriesProcess
     running: false
@@ -252,6 +278,9 @@ Item {
       if (exitCode !== 0) return
       root.countries = Model.parseProtonCountries(String(countriesStdout.text || ""))
       root.countriesLoaded = true
+      if (root.countries.length === 0) {
+        root.lastError = "Could not read the country list. Check: protonvpn countries list"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ actually have installed.
 
 It supports **Proton VPN**, **Mullvad**, and the **OpenVPN** and **WireGuard**
 profiles NetworkManager holds. Only the tools
-found on your machine appear — install none and the widget tells you so; install
-several and a chip row lets you switch between them.
+that have something to offer appear — install none and the widget tells you so;
+have several and a chip row lets you switch between them.
 
 <img src="preview.png" alt="The VPN panel open in the Omarchy bar, showing a Proton VPN connection to Zurich and a country list" width="365">
 
@@ -49,6 +49,11 @@ Inside the panel:
 - **The switch** top-right connects or disconnects. Turning one VPN on shuts
   every other one off first — you never end up with two tunnels fighting over
   your routes.
+- **The gear** to its left opens the widget's own settings, which for now is one
+  switch per tool found on this machine. Turn one off and the widget forgets it
+  entirely: no chip, no polling, and it stops counting toward the bar icon. Turn
+  it back on from the same place. The choice is written to
+  `~/.config/omarchy/shell.json` and survives a restart.
 - **The chips** below choose which tool you are looking at. They only appear
   when you have more than one installed.
 - **The name row** is also a drawer. Tools with settings of their own get a
@@ -68,8 +73,9 @@ Inside the panel:
 Keyboard, once the panel is open: `j`/`k` or arrows move — through the header,
 the chips, the name row, the settings switches if they are open, then the list —
 `Enter` connects, flips a switch, or opens and closes the settings drawer,
-depending on what the cursor is on. `h`/`l` move along the chip row, `s` cycles
-tools, `/` searches countries, `d` disconnects, `r` refreshes, `Esc` closes.
+depending on what the cursor is on. `h`/`l` move along the chip row and between
+the gear and the master switch in the header, `s` cycles tools, `/` searches
+countries, `d` disconnects, `r` refreshes, `Esc` closes.
 
 The public IP is fetched from `checkip.amazonaws.com` — never on a timer, only
 when the connection changes, when the panel first opens, or when you ask.
@@ -94,6 +100,7 @@ Configure these in **Setup › Plugins**, or in the widget's entry in
 | `refreshIntervalSec` | `15` | How often the connection status is polled |
 | `preferredBackend` | `Auto` | Which tool the panel opens on. `Auto` picks whichever is connected |
 | `favoriteCountries` | `CH,NL,US` | Country codes pinned to the top of the Proton VPN and Mullvad lists |
+| `hiddenBackends` | *(empty)* | Tools the widget ignores entirely: `proton`, `mullvad`, `networkmanager`. The gear inside the panel writes this |
 
 ## Mullvad
 
@@ -130,6 +137,11 @@ They share one chip, and the row icon says which is which. Import one with:
 nmcli connection import type openvpn file ~/Downloads/office.ovpn
 nmcli connection import type wireguard file ~/Downloads/home.conf
 ```
+
+NetworkManager runs on every desktop, so the chip appears only once you have a
+profile it can actually carry — an OpenVPN one with `openvpn` installed, or a
+WireGuard one with `wireguard-tools`. Until then the panel shows the import
+command above rather than a chip leading to an empty list.
 
 A tunnel you started some other way is not listed: a bare `openvpn` process,
 `openvpn-client@.service`, or a `wg-quick@` unit. Neither is a tunnel another

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ depending on what the cursor is on. `h`/`l` move along the chip row and between
 the gear and the master switch in the header, `s` cycles tools, `/` searches
 countries, `d` disconnects, `r` refreshes, `Esc` closes.
 
-The public IP is fetched from `checkip.amazonaws.com` — never on a timer, only
+The public IP is fetched from `https://checkip.amazonaws.com` — never on a timer, only
 when the connection changes, when the panel first opens, or when you ask.
 
 ## Requirements

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -18,7 +18,9 @@ import "Model.js" as Model
 //   emptyText                        shown when targets is empty
 //   toggles                          [{ key, label, detail, value, busy }] tool settings
 //   busy, actionStatus, lastError    transient feedback
-//   detect(), refresh()              probing
+//   detect(force)                    is the tool here? probing only — a hidden
+//                                    backend gets this and nothing else
+//   refresh()                        ask the tool where it stands
 //   connectTo(target), disconnect(), toggleConnection()
 //   setToggle(key, value)            flip one of the tool's own settings
 Item {
@@ -200,11 +202,22 @@ Item {
     var backend = root.active
     if (!backend) return
     if (backend.connected) {
-      clearNotice()
-      backend.disconnect()
+      disconnectActive()
       return
     }
     runExclusive(backend, function() { backend.toggleConnection() })
+  }
+
+  // Every disconnect goes through here rather than straight to the backend,
+  // because a connect still queued behind somebody else's teardown is part of
+  // the request being withdrawn. Left in place it lands seconds later and
+  // reconnects the tunnel the user just asked to bring down.
+  function disconnectActive() {
+    var backend = root.active
+    if (!backend) return
+    cancelPending()
+    clearNotice()
+    backend.disconnect()
   }
 
   // A warning about the connect that is about to run, kept here rather than on
@@ -230,11 +243,22 @@ Item {
     noticeTimer.stop()
   }
 
+  function cancelPending() {
+    exclusiveWait.running = false
+    exclusiveWait.ticks = 0
+    root._pendingAction = null
+    root._pendingBackend = null
+  }
+
   function runExclusive(backend, action) {
     clearNotice()
 
     var others = otherConnected(backend)
     if (others.length === 0) {
+      // Nothing to wait for — but something queued behind an earlier teardown
+      // may still be waiting, and it is the request this one replaces. Running
+      // both lands on the first target after the second one was asked for.
+      cancelPending()
       action()
       return
     }
@@ -295,18 +319,23 @@ Item {
 
   // A hidden tool is still probed — the settings view has to list it for you to
   // switch it back on — but never polled: not asking is the point of hiding it.
+  // The two calls are kept separate here rather than chained inside a backend,
+  // because a `detect()` that falls through to a refresh once probed would poll
+  // a hidden tool forever through the detect branch alone.
   //
   // Binaries do not come and go while the shell runs, so a tool that answered
   // "not installed" is asked once and then left alone; the poll would otherwise
   // spawn a probe per missing tool every interval, forever, to re-answer a
   // question whose answer never changed. `force` is the user asking — opening
   // the panel, pressing r, middle-clicking the icon — which is exactly when
-  // something might have been installed since.
+  // something might have been installed since, and the one time a hidden tool
+  // is looked at again so the settings view is not listing a stale machine.
   function refreshAll(force) {
     var recheck = force === true
     for (var i = 0; i < backends.length; i++) {
-      if (!backends[i].detected) backends[i].detect(recheck)
-      else if (!isHidden(backends[i].backendId)) backends[i].refresh()
+      backends[i].detect(recheck)
+      if (isHidden(backends[i].backendId)) continue
+      backends[i].refresh()
     }
   }
 

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -140,14 +140,19 @@ Item {
     onTriggered: root.refreshPublicIp()
   }
 
+  // Over HTTPS, and not by accident: a bare hostname would leave curl on plain
+  // HTTP, where anyone between this machine and the exit — the very party a
+  // VPN is run against — could hand back any address they liked and have the
+  // panel present it as proof the tunnel works. `--fail` keeps an error body
+  // out of the answer; the parser rejects anything that is not an address.
   Process {
     id: ipProcess
     running: false
-    command: ["curl", "--silent", "--max-time", "6", "checkip.amazonaws.com"]
+    command: ["curl", "--silent", "--fail", "--max-time", "6", "https://checkip.amazonaws.com"]
     stdout: StdioCollector { id: ipStdout; waitForEnd: true }
     onExited: function(exitCode) {
       root.ipFetching = false
-      var address = String(ipStdout.text || "").trim()
+      var address = Model.parsePublicIp(String(ipStdout.text || ""))
       if (exitCode === 0 && address !== "") {
         root.publicIp = address
         root.ipFailed = false
@@ -195,13 +200,39 @@ Item {
     var backend = root.active
     if (!backend) return
     if (backend.connected) {
+      clearNotice()
       backend.disconnect()
       return
     }
     runExclusive(backend, function() { backend.toggleConnection() })
   }
 
+  // A warning about the connect that is about to run, kept here rather than on
+  // the backend's lastError — connectTo() clears that as its first act, so the
+  // action being warned about would wipe the warning on its way out. Expires on
+  // its own, since it describes one attempt and not a standing condition.
+  property string notice: ""
+
+  Timer {
+    id: noticeTimer
+    interval: 12000
+    repeat: false
+    onTriggered: root.notice = ""
+  }
+
+  function setNotice(text) {
+    root.notice = text
+    noticeTimer.restart()
+  }
+
+  function clearNotice() {
+    root.notice = ""
+    noticeTimer.stop()
+  }
+
   function runExclusive(backend, action) {
+    clearNotice()
+
     var others = otherConnected(backend)
     if (others.length === 0) {
       action()
@@ -213,14 +244,19 @@ Item {
       // down, which is exactly when the incoming connect needs the network.
       // Say so up front rather than let it fail as a timeout.
       if (others[i].lockdownMode === true) {
-        backend.lastError = others[i].label + " blocks all traffic while it is disconnected, "
-          + "so connecting will not get through. Turn it off with: mullvad lockdown-mode set off"
+        setNotice(others[i].label + " blocks all traffic while it is disconnected, "
+          + "so connecting will not get through. Turn it off with: mullvad lockdown-mode set off")
       }
       others[i].disconnect()
     }
+    // Picking a second target while the first is still waiting means the second
+    // one: nobody clicks two countries wanting both. The deadline stays where
+    // the first click put it, though — resetting it on every click would let an
+    // impatient user push the bail-out back indefinitely and leave the panel
+    // waiting on a teardown that is never going to land.
+    if (!exclusiveWait.running) exclusiveWait.ticks = 0
     root._pendingAction = action
     root._pendingBackend = backend
-    exclusiveWait.ticks = 0
     exclusiveWait.restart()
   }
 
@@ -259,9 +295,17 @@ Item {
 
   // A hidden tool is still probed — the settings view has to list it for you to
   // switch it back on — but never polled: not asking is the point of hiding it.
-  function refreshAll() {
+  //
+  // Binaries do not come and go while the shell runs, so a tool that answered
+  // "not installed" is asked once and then left alone; the poll would otherwise
+  // spawn a probe per missing tool every interval, forever, to re-answer a
+  // question whose answer never changed. `force` is the user asking — opening
+  // the panel, pressing r, middle-clicking the icon — which is exactly when
+  // something might have been installed since.
+  function refreshAll(force) {
+    var recheck = force === true
     for (var i = 0; i < backends.length; i++) {
-      if (!backends[i].detected) backends[i].detect()
+      if (!backends[i].detected) backends[i].detect(recheck)
       else if (!isHidden(backends[i].backendId)) backends[i].refresh()
     }
   }

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -10,7 +10,8 @@ import "Model.js" as Model
 //   backendId, label, glyph          identity for the switcher chips
 //   supportsFilter, filterPlaceholder whether the panel shows its filter field
 //   filter                           panel writes the current filter text here
-//   detected                         tool is installed and usable
+//   detected                         tool is installed and has something to offer
+//   setupHint                        optional: what to do about being undetected
 //   connected, summary               headline state
 //   details                          [{ label, value }] shown while connected
 //   targets                          [{ key, label, detail, glyph, args }]
@@ -30,8 +31,19 @@ Item {
   property string selectedId: ""
 
   readonly property var backends: [proton, mullvad, networkManager]
-  readonly property var availableBackends: backends.filter(function(backend) { return backend.detected })
+  // Tools this machine has. Hiding one is a statement about the widget, not
+  // about the machine, so the settings view lists these — including the hidden
+  // ones, which would otherwise be unreachable once they were switched off.
+  readonly property var detectedBackends: backends.filter(function(backend) { return backend.detected })
+  readonly property var hiddenBackendIds: Model.parseBackendIds(setting("hiddenBackends", ""))
+  readonly property var availableBackends: detectedBackends.filter(function(backend) {
+    return !root.isHidden(backend.backendId)
+  })
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 15, 5, 600)
+
+  function isHidden(backendId) {
+    return hiddenBackendIds.indexOf(String(backendId)) !== -1
+  }
 
   readonly property var active: {
     var available = availableBackends
@@ -68,7 +80,9 @@ Item {
   }
 
   readonly property string barSummary: {
-    if (!anyDetected) return "No VPN tool installed"
+    if (!anyDetected) {
+      return detectedBackends.length > 0 ? "Every VPN tool is hidden" : "No VPN tool installed"
+    }
     var backend = connectedBackend
     if (!backend) return "Not connected"
     return backend.label + " · " + backend.summary
@@ -77,6 +91,18 @@ Item {
   readonly property var switcherOptions: availableBackends.map(function(backend) {
     return { value: backend.backendId, label: backend.label }
   })
+
+  // An installed tool with nothing to show hides itself, so the panel would
+  // otherwise tell you to install what you already have. Optional: a backend
+  // without the property simply has nothing to say.
+  readonly property string setupHint: {
+    for (var i = 0; i < backends.length; i++) {
+      if (isHidden(backends[i].backendId)) continue
+      var hint = backends[i].setupHint
+      if (hint !== undefined && String(hint) !== "") return String(hint)
+    }
+    return ""
+  }
 
   // ------------------------------------------------------------- public IP
 
@@ -231,10 +257,12 @@ Item {
     }
   }
 
+  // A hidden tool is still probed — the settings view has to list it for you to
+  // switch it back on — but never polled: not asking is the point of hiding it.
   function refreshAll() {
     for (var i = 0; i < backends.length; i++) {
-      if (backends[i].detected) backends[i].refresh()
-      else backends[i].detect()
+      if (!backends[i].detected) backends[i].detect()
+      else if (!isHidden(backends[i].backendId)) backends[i].refresh()
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "jkoestinger.vpn",
   "name": "VPN",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Justin",
   "license": "MIT",
   "description": "VPN status and switching in the Omarchy bar, across whichever VPN tools are installed.",

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
     "defaults": {
       "refreshIntervalSec": 15,
       "preferredBackend": "Auto",
-      "favoriteCountries": "CH,NL,US"
+      "favoriteCountries": "CH,NL,US",
+      "hiddenBackends": ""
     },
     "schema": [
       {
@@ -46,6 +47,13 @@
         "type": "string",
         "label": "Favorite countries (comma separated)",
         "defaultValue": "CH,NL,US"
+      },
+      {
+        "key": "hiddenBackends",
+        "type": "string",
+        "label": "Hidden VPN tools (comma separated)",
+        "defaultValue": "",
+        "description": "Tools the widget ignores entirely: proton, mullvad, networkmanager. Also editable from the gear inside the panel."
       }
     ]
   }

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,0 +1,429 @@
+// Tests for Model.js — the pure half of the widget, where every assumption
+// about how three CLIs format their output is written down.
+//
+//   node tests/run.js
+//
+// No dependencies and no test framework: the plugin ships no package.json and
+// is not built, so a test suite that needed installing would not get run.
+//
+// Model.js is a QML `.pragma library`, which has no module system — just
+// top-level declarations. Running it in this realm's global scope turns those
+// into globals, which is as close to importing it as node gets without a QML
+// engine; collecting the names it added gives back something shaped like a
+// module. A fresh VM context would be tidier, but its arrays would carry that
+// context's prototypes and every deepStrictEqual would fail on realm alone.
+
+const fs = require("fs")
+const path = require("path")
+const vm = require("vm")
+const assert = require("assert")
+
+const source = fs.readFileSync(path.join(__dirname, "..", "Model.js"), "utf8")
+  .replace(/^\s*\.pragma\s+library\s*$/m, "")
+
+const before = new Set(Object.getOwnPropertyNames(globalThis))
+vm.runInThisContext(source, { filename: "Model.js" })
+
+const Model = {}
+for (const name of Object.getOwnPropertyNames(globalThis)) {
+  if (!before.has(name)) Model[name] = globalThis[name]
+}
+
+let passed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed += 1
+  } catch (error) {
+    failures.push({ name: name, error: error })
+  }
+}
+
+const eq = assert.deepStrictEqual
+
+// ------------------------------------------------------------------ shared
+
+test("elide keeps short text and collapses whitespace", () => {
+  eq(Model.elide("  a   b  ", 10), "a b")
+  eq(Model.elide("abcdefghij", 10), "abcdefghij")
+  eq(Model.elide("abcdefghijk", 10), "abcdefghi…")
+  eq(Model.elide(null, 10), "")
+})
+
+test("applyPendingToggles marks only the flipped switch busy", () => {
+  const toggles = [Model.toggle("a", "A", "", false), Model.toggle("b", "B", "", true)]
+  const applied = Model.applyPendingToggles(toggles, { a: true })
+  eq(applied[0].value, true)
+  eq(applied[0].busy, true)
+  eq(applied[1].value, true)
+  eq(applied[1].busy, false)
+  eq(Model.applyPendingToggles(toggles, null), toggles)
+})
+
+test("backend id lists round-trip through the comma-separated setting", () => {
+  eq(Model.parseBackendIds(" Proton , mullvad ,, proton "), ["proton", "mullvad"])
+  eq(Model.parseBackendIds(null), [])
+  eq(Model.joinBackendIds(["proton", "mullvad"]), "proton,mullvad")
+  eq(Model.toggleBackendId(["proton"], "mullvad"), ["proton", "mullvad"])
+  eq(Model.toggleBackendId(["proton", "mullvad"], "proton"), ["mullvad"])
+})
+
+// --------------------------------------------------------------- public IP
+
+test("parsePublicIp accepts address literals", () => {
+  eq(Model.parsePublicIp("1.2.3.4"), "1.2.3.4")
+  eq(Model.parsePublicIp("  8.8.8.8\n"), "8.8.8.8")
+  eq(Model.parsePublicIp("2001:DB8::1"), "2001:db8::1")
+})
+
+test("parsePublicIp rejects anything that is not one", () => {
+  // A captive portal's login page, an error body, a spoofed answer with a
+  // trailer: none of these are an exit address, and rendering one would be the
+  // widget confirming a route it never saw.
+  eq(Model.parsePublicIp("<html>Sign in</html>"), "")
+  eq(Model.parsePublicIp("1.2.3.4 extra"), "")
+  eq(Model.parsePublicIp("999.1.1.1"), "")
+  eq(Model.parsePublicIp("deadbeef"), "")
+  eq(Model.parsePublicIp("1:2:::3"), "")
+  eq(Model.parsePublicIp("::1::2"), "")
+  eq(Model.parsePublicIp(""), "")
+  eq(Model.parsePublicIp(null), "")
+  eq(Model.parsePublicIp("1.2.3.4".padEnd(50, "0")), "")
+})
+
+// ------------------------------------------------------------- Proton VPN
+
+test("parseProtonStatus reads the labelled block", () => {
+  const status = Model.parseProtonStatus([
+    "Status: Connected",
+    "Server: NL#42",
+    "Country: Netherlands",
+    "Load: 40%",
+    "Protocol: WireGuard"
+  ].join("\n"))
+  eq(status.connected, true)
+  eq(status.server, "NL#42")
+  eq(status.country, "Netherlands")
+  eq(status.load, "40%")
+  eq(status.protocol, "WireGuard")
+})
+
+test("parseProtonStatus splits the combined server-and-place field", () => {
+  const status = Model.parseProtonStatus("Status: Connected\nServer: CH#1129 in Zurich, Switzerland")
+  eq(status.server, "CH#1129")
+  eq(status.city, "Zurich")
+  eq(status.country, "Switzerland")
+  eq(Model.protonSummary(status), "CH#1129 · Zurich, Switzerland")
+})
+
+test("parseProtonStatus reads the older bare sentence", () => {
+  const status = Model.parseProtonStatus("Connected to NL#42")
+  eq(status.connected, true)
+  eq(status.server, "NL#42")
+})
+
+test("parseProtonStatus treats disconnected and noise as not connected", () => {
+  eq(Model.parseProtonStatus("Status: Disconnected").connected, false)
+  eq(Model.parseProtonStatus("").connected, false)
+  eq(Model.parseProtonStatus("garbage\n\n---").connected, false)
+  eq(Model.parseProtonStatus("").statusText, "Disconnected")
+  eq(Model.protonSummary(Model.parseProtonStatus("")), "Not connected")
+})
+
+test("parseProtonCountries skips the header, the rule, and the notice", () => {
+  eq(Model.parseProtonCountries([
+    "Server list is outdated, updating...",
+    "Country                  Code",
+    "-----------------------  ----",
+    "Netherlands              NL",
+    "United States            US"
+  ].join("\n")), [
+    { name: "Netherlands", code: "NL" },
+    { name: "United States", code: "US" }
+  ])
+})
+
+test("parseProtonConfig reads the two-column table", () => {
+  const config = Model.parseProtonConfig([
+    "Setting                  Value",
+    "-----------------------  ------------",
+    "netshield                malware-only",
+    "kill-switch              off"
+  ].join("\n"))
+  eq(config.loaded, true)
+  eq(config.values["netshield"], "malware-only")
+  eq(config.values["kill-switch"], "off")
+  eq(Model.parseProtonConfig("").loaded, false)
+})
+
+test("protonToggles reports mode-carrying settings as on", () => {
+  const config = Model.parseProtonConfig("netshield  malware-only\nkill-switch  advanced")
+  const toggles = Model.protonToggles(config)
+  eq(toggles.map(t => t.key), ["kill-switch", "netshield", "port-forwarding"])
+  eq(toggles[0].value, true)
+  eq(toggles[0].detail, "Mode: advanced")
+  eq(toggles[1].value, true)
+  eq(toggles[1].detail, "Blocking: malware-only")
+  eq(toggles[2].value, false)
+  eq(Model.protonToggles(Model.parseProtonConfig("")), [])
+})
+
+test("protonToggleArgs restores the remembered mode instead of a default", () => {
+  // Switching NetShield off and on again must not silently upgrade a
+  // deliberate "malware-only" to the wider default.
+  eq(Model.protonToggleArgs("netshield", true, "malware-only"),
+    ["config", "set", "netshield", "malware-only"])
+  eq(Model.protonToggleArgs("netshield", true, ""),
+    ["config", "set", "netshield", "malware-ads-trackers"])
+  eq(Model.protonToggleArgs("kill-switch", true, ""),
+    ["config", "set", "kill-switch", "standard"])
+  eq(Model.protonToggleArgs("netshield", false, "malware-only"),
+    ["config", "set", "netshield", "off"])
+  eq(Model.protonToggleArgs("nonsense", true, ""), [])
+})
+
+test("protonModes remembers the last non-off value", () => {
+  const first = Model.protonModes(Model.parseProtonConfig("netshield  malware-only"), {})
+  eq(first["netshield"], "malware-only")
+  const after = Model.protonModes(Model.parseProtonConfig("netshield  off"), first)
+  eq(after["netshield"], "malware-only")
+})
+
+test("protonCountryTargets puts favorites first and filters over name and code", () => {
+  const countries = [
+    { name: "Netherlands", code: "NL" },
+    { name: "Switzerland", code: "CH" }
+  ]
+  eq(Model.protonCountryTargets(countries, ["CH"], "").map(t => t.label),
+    ["Switzerland", "Netherlands"])
+  eq(Model.protonCountryTargets(countries, ["CH"], "nl").map(t => t.label), ["Netherlands"])
+  eq(Model.protonCountryTargets(countries, [], "zzz"), [])
+  eq(Model.protonCountryTargets(countries, [], "")[0].args, ["--country", "NL"])
+})
+
+test("favoriteCodes normalises and de-duplicates", () => {
+  eq(Model.favoriteCodes(" ch , NL ,ch, "), ["CH", "NL"])
+  eq(Model.favoriteCodes(null), [])
+})
+
+// ----------------------------------------------------------- NetworkManager
+
+test("splitNmcliLine splits on the first unescaped colon", () => {
+  eq(Model.splitNmcliLine("home\\:vpn:uuid-1"), ["home:vpn", "uuid-1"])
+  eq(Model.splitNmcliLine("plain"), ["plain", ""])
+})
+
+test("parseNmcliConnections keeps only tunnels", () => {
+  eq(Model.parseNmcliConnections([
+    "Work VPN:uuid-1:vpn:yes:/etc/NetworkManager/system-connections/work.nmconnection",
+    "Home WG:uuid-2:wireguard:no:/etc/NetworkManager/system-connections/home.nmconnection",
+    "Wired:uuid-3:ethernet:yes:/etc/NetworkManager/system-connections/wired.nmconnection",
+    ""
+  ].join("\n")), [
+    { name: "Work VPN", uuid: "uuid-1", kind: "vpn", active: true },
+    { name: "Home WG", uuid: "uuid-2", kind: "wireguard", active: false }
+  ])
+})
+
+test("parseNmcliConnections drops another tool's volatile connection", () => {
+  // Mullvad brings up wg0-mullvad itself; NetworkManager adopts the device and
+  // generates a profile under /run. Listing it would put one tunnel on two
+  // chips and let nmcli yank it out from under the tool that owns it.
+  eq(Model.parseNmcliConnections(
+    "wg0-mullvad:uuid-9:wireguard:yes:/run/NetworkManager/system-connections/wg0-mullvad.nmconnection"
+  ), [])
+})
+
+test("parseNmcliConnections keeps rows from an nmcli with no FILENAME field", () => {
+  // The older-nmcli fallback: the field is dropped from the query and the
+  // connection is kept, since a stray row beats a backend that lists nothing.
+  eq(Model.parseNmcliConnections("Work VPN:uuid-1:vpn:yes"), [
+    { name: "Work VPN", uuid: "uuid-1", kind: "vpn", active: true }
+  ])
+})
+
+test("parseNmcliVpnDetails reads one block per connection", () => {
+  const details = Model.parseNmcliVpnDetails([
+    "connection.uuid:uuid-1",
+    "vpn.service-type:org.freedesktop.NetworkManager.openvpn",
+    "vpn.data:username = alice, comp-lzo = adaptive",
+    "",
+    "connection.uuid:uuid-2",
+    "vpn.service-type:org.freedesktop.NetworkManager.fortisslvpn",
+    "vpn.data:comp-lzo = adaptive"
+  ].join("\n"))
+  eq(Object.keys(details).sort(), ["uuid-1", "uuid-2"])
+  eq(details["uuid-1"].hasUsername, true)
+  eq(Model.isOpenVpnService(details["uuid-1"].serviceType), true)
+  eq(details["uuid-2"].hasUsername, false)
+  eq(Model.isOpenVpnService(details["uuid-2"].serviceType), false)
+})
+
+test("hasVpnUsername ignores an empty username", () => {
+  eq(Model.hasVpnUsername("username = alice"), true)
+  eq(Model.hasVpnUsername("username = "), false)
+  eq(Model.hasVpnUsername("comp-lzo = adaptive"), false)
+  eq(Model.hasVpnUsername(""), false)
+})
+
+test("nmTargets flags an OpenVPN profile with no username", () => {
+  const targets = Model.nmTargets([
+    { name: "Work", uuid: "uuid-1", kind: "vpn", active: false, hasUsername: false },
+    { name: "Home", uuid: "uuid-2", kind: "wireguard", active: false },
+    { name: "Live", uuid: "uuid-3", kind: "vpn", active: true, hasUsername: true }
+  ])
+  eq(targets[0].detail, "No username set")
+  // WireGuard keeps its keys in the profile, so there is nothing to leave out.
+  eq(targets[1].detail, "WireGuard profile")
+  eq(targets[2].detail, "Connected")
+  eq(targets[0].args, ["connection", "up", "uuid", "uuid-1"])
+})
+
+test("nmSummary tells no profiles from none connected", () => {
+  eq(Model.nmSummary([]), "No profiles")
+  eq(Model.nmSummary([{ name: "Work", active: false }]), "Not connected")
+  eq(Model.nmSummary([{ name: "Work", active: true }]), "Work")
+})
+
+// ------------------------------------------------------------------ Mullvad
+
+test("parseMullvadStatus reads a connected payload", () => {
+  const status = Model.parseMullvadStatus(JSON.stringify({
+    state: "connected",
+    details: {
+      location: { hostname: "ch-zrh-wg-001", country: "Switzerland", city: "Zurich", ipv4: "1.2.3.4" },
+      endpoint: { address: "185.156.46.146:51820", protocol: "udp", tunnel_interface: "wg0-mullvad" },
+      feature_indicators: ["QuantumResistance"]
+    }
+  }))
+  eq(status.connected, true)
+  eq(status.relay, "ch-zrh-wg-001")
+  eq(status.protocol, "UDP")
+  eq(status.features, ["Quantum Resistance"])
+  eq(Model.mullvadSummary(status), "ch-zrh-wg-001 · Zurich, Switzerland")
+})
+
+test("parseMullvadStatus treats unparseable output as no idea", () => {
+  // Not as disconnected: claiming the tunnel is down when the answer was
+  // unreadable is the wrong direction to guess in.
+  eq(Model.parseMullvadStatus("not json").state, "")
+  eq(Model.parseMullvadStatus("").state, "")
+  eq(Model.parseMullvadStatus("[1,2]").state, "")
+  eq(Model.mullvadSummary(Model.parseMullvadStatus("")), "Checking…")
+})
+
+test("parseMullvadStatus survives details being a bare string", () => {
+  const status = Model.parseMullvadStatus('{"state":"disconnecting","details":"reconnect"}')
+  eq(status.state, "disconnecting")
+  eq(status.connected, false)
+})
+
+test("mullvadSummary names the blocked state for what it is", () => {
+  const blocked = Model.parseMullvadStatus('{"state":"error"}')
+  eq(blocked.blocked, true)
+  eq(Model.mullvadSummary(blocked), "Blocked — no traffic is leaving this machine")
+  const lockedDown = Model.parseMullvadStatus('{"state":"disconnected","details":{"locked_down":true}}')
+  eq(Model.mullvadSummary(lockedDown), "Not connected · traffic blocked")
+})
+
+test("mullvadIndentDepth counts a tab and four spaces alike", () => {
+  eq(Model.mullvadIndentDepth("Switzerland (ch)"), 0)
+  eq(Model.mullvadIndentDepth("\tZurich (zrh)"), 1)
+  eq(Model.mullvadIndentDepth("    Zurich (zrh)"), 1)
+  eq(Model.mullvadIndentDepth("\t\tch-zrh-wg-001"), 2)
+})
+
+test("parseMullvadRelays keeps countries and cities, not relays", () => {
+  eq(Model.parseMullvadRelays([
+    "Switzerland (ch)",
+    "\tZurich (zrh) @ 47.36667°N, 8.55000°W",
+    "\t\tch-zrh-wg-001 (185.156.46.146) - hosted by 31173 (rented)",
+    "Netherlands (nl)",
+    "\tAmsterdam (ams) @ 52.35°N, 4.9°E"
+  ].join("\n")), [
+    { name: "Switzerland", code: "CH", cities: [{ name: "Zurich", code: "zrh" }] },
+    { name: "Netherlands", code: "NL", cities: [{ name: "Amsterdam", code: "ams" }] }
+  ])
+  eq(Model.parseMullvadRelays(""), [])
+})
+
+test("mullvadCountryTargets filters over city names too", () => {
+  const countries = Model.parseMullvadRelays([
+    "Switzerland (ch)",
+    "\tZurich (zrh)",
+    "Netherlands (nl)",
+    "\tAmsterdam (ams)"
+  ].join("\n"))
+  eq(Model.mullvadCountryTargets(countries, [], "zurich").map(t => t.label), ["Switzerland"])
+  eq(Model.mullvadCountryTargets(countries, ["NL"], "").map(t => t.label),
+    ["Netherlands", "Switzerland"])
+  eq(Model.mullvadCountryTargets(countries, [], "")[0].detail, "CH · 1 city")
+  eq(Model.mullvadCountryTargets(countries, [], "")[0].args, ["ch"])
+})
+
+test("mullvadCurrentKey prefers the hostname over the country name", () => {
+  const countries = [{ name: "Switzerland", code: "CH", cities: [] }]
+  eq(Model.mullvadCurrentKey({ state: "connected", relay: "ch-zrh-wg-504", country: "" }, countries),
+    "country:CH")
+  // Mid-connect the hostname is not reported yet, so the name has to carry it.
+  eq(Model.mullvadCurrentKey({ state: "connecting", relay: "", country: "Switzerland" }, countries),
+    "country:CH")
+  eq(Model.mullvadCurrentKey({ state: "disconnected", relay: "ch-zrh-wg-504", country: "" }, countries), "")
+})
+
+test("parseMullvadSettings marks each answer it actually saw", () => {
+  const all = Model.parseMullvadSettings([
+    "Autoconnect: off",
+    "Block traffic when the VPN is disconnected: on",
+    "Local network sharing setting: allow"
+  ].join("\n"))
+  eq(all.loaded, true)
+  eq(all.autoconnect, false)
+  eq(all.lockdown, true)
+  eq(all.lan, true)
+  eq(all.seen, { autoconnect: true, lockdown: true, lan: true })
+})
+
+test("parseMullvadSettings does not report an unanswered setting as off", () => {
+  // One shell, one exit code — the last subcommand's — so a failed
+  // `lockdown-mode get` leaves no line and no error. Reporting lockdown mode as
+  // off while it is on is the one mistake this widget must not make.
+  const partial = Model.parseMullvadSettings("Autoconnect: on\n")
+  eq(partial.loaded, true)
+  eq(partial.seen, { autoconnect: true })
+  eq(Model.mullvadToggles(partial).map(t => t.key), ["autoconnect"])
+
+  // Each branch answers for itself and for nothing else — the middle
+  // subcommand succeeding says nothing about the two around it.
+  const middle = Model.parseMullvadSettings("Block traffic when the VPN is disconnected: on\n")
+  eq(middle.seen, { lockdown: true })
+  eq(Model.mullvadToggles(middle).map(t => t.key), ["lockdown"])
+  const last = Model.parseMullvadSettings("Local network sharing setting: allow\n")
+  eq(last.seen, { lan: true })
+  eq(Model.mullvadToggles(last).map(t => t.key), ["lan"])
+
+  const none = Model.parseMullvadSettings("")
+  eq(none.loaded, false)
+  eq(none.seen, {})
+  eq(Model.mullvadToggles(none), [])
+})
+
+test("mullvadToggleArgs speaks each setting's own vocabulary", () => {
+  eq(Model.mullvadToggleArgs("autoconnect", true), ["auto-connect", "set", "on"])
+  eq(Model.mullvadToggleArgs("lockdown", false), ["lockdown-mode", "set", "off"])
+  eq(Model.mullvadToggleArgs("lan", true), ["lan", "set", "allow"])
+  eq(Model.mullvadToggleArgs("lan", false), ["lan", "set", "block"])
+  eq(Model.mullvadToggleArgs("nonsense", true), [])
+})
+
+// ------------------------------------------------------------------ report
+
+for (const failure of failures) {
+  console.error("FAIL  " + failure.name)
+  console.error("      " + String(failure.error.message).split("\n").join("\n      "))
+}
+
+console.log(`${passed} passed, ${failures.length} failed`)
+process.exit(failures.length === 0 ? 0 : 1)


### PR DESCRIPTION
Everything on `dev` since 1.0.0, plus the manifest bump and a new `CHANGELOG.md`.

Minor rather than patch on the strength of one feature. Nothing about the settings schema or the IPC surface breaks, so an existing `shell.json` entry keeps working untouched.

## What is in it

| Commit | |
|---|---|
| `bc1f745` | feat: hide tools with nothing to offer, add a widget settings view |
| `33c9e6a` | fix: stop the panel vouching for protection it never verified |
| `cc2f1b3` | fix: stop a cancelled connect from coming back to life |
| `63e284a` | chore: release 1.1.0 |

### Added

- A gear in the panel header opens the widget's own settings: one switch per VPN tool found on this machine. Turn one off and the widget forgets it entirely — no chip, no polling, no weight in the bar icon. Persisted as `hiddenBackends` in the same `shell.json` entry Omarchy's settings dialog edits.
- NetworkManager appears only once it has a profile it can actually carry, rather than drawing a chip that led to an empty list.

### Fixed — the ones that mattered

- The master switch bound its position to "anything is connected" while its click acted on the tool being looked at, so with Mullvad up and the Proton chip picked it read "Disconnect", then tore Mullvad down and brought Proton up.
- Mullvad's lockdown mode could be drawn as **off while it was on**: three settings read in one shell share one exit code, so a failed `lockdown-mode get` left no line and no error, and the parser read the silence as "off". That also silently disarmed the warning shown before Mullvad is torn down for another tool.
- The public IP was fetched over plain HTTP, where anyone on the path could hand back any address and have the panel present it as proof the tunnel works. HTTPS with `--fail` now, and the answer is believed only if it parses as an address literal.
- A connect queued behind another tool's teardown was never cancelled, so pressing `d` or picking a second country left the first request to fire seconds later and bring up a tunnel already called off.
- `connect <country code>` over IPC only ever worked for Proton VPN.
- A hidden NetworkManager kept polling `nmcli` every interval.

Full list in [CHANGELOG.md](https://github.com/jkoestinger/omarchy-vpn/blob/release/1.1.0/CHANGELOG.md).

## Checks

- `node tests/run.js` — 35 passed, 0 failed
- `qmllint -I /usr/share/omarchy/shell` — clean on all five QML files
- `omarchy plugin validate .` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)