### PR TITLE
feat: add a Windscribe backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,7 @@ a tool means writing one file and adding one line.
 | `VpnController.qml` | Owns the backends, picks the active one, enforces exclusivity, fetches the public IP |
 | `ProtonBackend.qml` | Proton VPN, via the `protonvpn` CLI |
 | `MullvadBackend.qml` | Mullvad, via the `mullvad` CLI |
+| `WindscribeBackend.qml` | Windscribe, via `windscribe-cli` |
 | `NetworkManagerBackend.qml` | OpenVPN and WireGuard, via NetworkManager |
 | `Model.js` | Pure parsing and row-building. No QML, no side effects |
 
@@ -25,7 +26,7 @@ duck-types, so a backend that omits something simply renders as blank.
 
 | Property | Meaning |
 |----------|---------|
-| `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `networkmanager`) |
+| `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `windscribe`, `networkmanager`) |
 | `label` | Name on the switcher chip and hero |
 | `glyph` | Nerd Font character for the hero icon |
 | `supportsFilter`, `filterPlaceholder` | Whether the panel shows its filter field |
@@ -57,13 +58,14 @@ otherwise keep polling a tool the user switched off. `refresh()` guards itself,
 so the controller can call it unconditionally.
 
 `toggleConnection()` is the backend's own idea of a default connection — Proton
-picks the fastest server; Mullvad reuses its stored relay constraint;
-NetworkManager connects the only profile if there is exactly one, and otherwise
-asks the user to pick.
+picks the fastest server; Mullvad reuses its stored relay constraint; Windscribe
+takes its best location; NetworkManager connects the only profile if there is
+exactly one, and otherwise asks the user to pick.
 
 A backend may also expose `lockdownMode`, meaning "this tool blocks all traffic
 while it is disconnected". The controller warns about it before tearing that
-backend down for another one.
+backend down for another one, and names the command from the backend's
+`lockdownHint` so the warning is not written in one tool's vocabulary.
 
 It may also expose `setupHint`: one line explaining why it is not `detected`
 and what would change that. The panel shows the first non-empty hint in place
@@ -133,6 +135,62 @@ the hero exactly as it was — no empty drawer, no dead handle. The open/closed
 state lives on the panel, so it survives a close and reopen but not a shell
 restart, and folding the drawer while the cursor is inside it moves the cursor
 back to the hero rather than stranding it.
+
+**Windscribe is a client, twice over.** `windscribe-cli` talks to the Windscribe
+desktop app, so the binary being present says nothing: an app that is not running
+answers nothing, and one nobody is logged into has no locations and cannot
+connect. `detected` is therefore `present && loggedIn`, which takes a status read
+to answer — so `detect()` runs two commands rather than one, and the two failures
+are told apart in `setupHint`.
+
+**Windscribe takes a lock, and the widget is not one process.** Two
+`windscribe-cli` invocations may not overlap: the second exits with `Windscribe
+CLI is already running` and does no work, so a pair started together loses both
+answers. Every call the backend makes therefore goes through one queue and one
+process, with reads deduplicated (a status poll already in flight is not queued
+behind itself) and clicks pushed to the front.
+
+That much is only half the problem, and the half that is easy to mistake for all
+of it. The lock is per machine, and each bar instantiates the widget separately —
+so a two-monitor desktop runs two of these queues, each perfectly disciplined and
+each blind to the other. They poll on the same interval, so they collide on the
+same tick, and both lose. A backend that treated the refusal as an answer would
+hide itself on whichever screen came second, intermittently, for reasons nothing
+in one instance could explain.
+
+So a refusal is not a result. The job goes back to the head of its own queue and
+is tried again, up to four times, after a jittered delay — jittered because two
+instances that lost together would otherwise back off by the same amount and
+collide again on every round, and the attempt count is identical on both sides so
+it cannot be what breaks the tie. Past the last attempt the finisher runs and
+treats the refusal as inconclusive rather than as news; the next poll asks again.
+The same path covers the user running the CLI at a terminal, which is the case
+that cannot be designed away.
+
+Any *other* unreadable status is the app being gone, and there the last reading is
+dropped rather than left on screen. A stall timer covers the remaining way for
+"one at a time" to fail: a job that never comes back would leave `_running` set,
+and since a read already in flight is never queued twice, the backend would
+quietly stop asking about the tunnel for as long as the shell ran.
+
+**Windscribe connects non-blocking.** `connect -n` returns as soon as the daemon
+accepts the request. A blocking call would hold the CLI lock — and with it every
+status read — for the whole handshake, which is exactly the stretch the panel has
+something to say. The cost is that the exit code stops meaning anything: a free
+account reaching for a Pro location is accepted, exits 0, and fails seconds later
+with nothing but `Connect state: Error: …` to show for it. So the optimistic
+state is dropped the moment a status read reports that error, rather than waiting
+out the settle timer and vouching for a tunnel that never came up. The error is
+sticky in the CLI — it stands until the next successful connect — so the backend
+both raises and clears it from the same reading.
+
+**Windscribe rows are regions, not countries.** `windscribe-cli locations` prints
+`Region - City - Nickname`, and `connect` takes any of the three. Regions are the
+grouping the tool itself uses and the shortest useful list, so they are what the
+panel shows; cities and nicknames stay searchable. `status` names only the city
+and the nickname, never the region, so the row to tick is looked back up in the
+list — city first across every region, since two regions sharing a nickname is
+likelier than two sharing a city.
 
 **Two kinds of settings, two places.** The drawer above holds the *tool's*
 settings, which the widget only reflects. The gear in the header holds the
@@ -264,7 +322,7 @@ Check a manifest change with `omarchy plugin validate .` before committing.
 
 ## Tests
 
-`Model.js` is where every assumption about how three CLIs format their output
+`Model.js` is where every assumption about how four CLIs format their output
 lives, and it is the one file that runs without a QML engine. The suite covers
 it:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,11 +167,36 @@ treats the refusal as inconclusive rather than as news; the next poll asks again
 The same path covers the user running the CLI at a terminal, which is the case
 that cannot be designed away.
 
-Any *other* unreadable status is the app being gone, and there the last reading is
-dropped rather than left on screen. A stall timer covers the remaining way for
-"one at a time" to fail: a job that never comes back would leave `_running` set,
-and since a read already in flight is never queued twice, the backend would
-quietly stop asking about the tunnel for as long as the shell ran.
+A stall timer covers the remaining way for "one at a time" to fail: a job that
+never comes back would hold the runner slot forever, and since a read already in
+flight is never queued twice, the backend would quietly stop asking about the
+tunnel for as long as the shell ran. It **kills** the process rather than
+forgetting it — a forgotten one still holds the machine-wide lock, blocking every
+other copy of the widget as well as this one, while nothing could start behind
+it. Killing makes `onExited` fire and the usual path does the bookkeeping.
+
+Nothing in the queue waits on a zero-interval timer. `pump` never arranges to be
+called back while a job is on the wire; the running job's `onExited` is what
+pumps. An earlier version re-armed a 0 ms timer there, which turned a hung CLI
+into a shell spinning through its event loop for the length of the hang.
+
+The queue rules themselves — dedupe, front-insertion, bounded retry, backoff —
+live in `Model.js` as a reducer over `(queue, running job)`, because they are
+logic rather than plumbing and they are the part that has been wrong.
+
+**A status that cannot be read is stale, not empty.** The last reading is kept
+and flagged, never replaced with a blank one, and two things hang on that.
+`detected` follows the login state, so blanking would take the chip away while a
+tunnel is up — and with it the only way to bring that tunnel down, since every
+verb refuses to run undetected. That is the hazard NetworkManagerBackend keeps
+its own stale list to avoid. And a blank status reports the firewall as off:
+losing contact with the app is exactly when the widget must not start claiming
+that nothing is being blocked.
+
+For the same reason a firewall line this parser cannot read counts as "might be
+blocking" when the controller weighs whether to warn, even though the summary
+line still reports only what the tool actually said. One weighs a risk, the
+other states a fact.
 
 **Windscribe connects non-blocking.** `connect -n` returns as soon as the daemon
 accepts the request. A blocking call would hold the CLI lock — and with it every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Windscribe**, via `windscribe-cli`. Best location followed by every region
+  Windscribe serves, with cities and server nicknames searchable; the firewall
+  as a switch in the tool drawer; and the data allowance on the detail rows,
+  since a free plan is metered and the CLI prints the number nowhere else.
+  Regions holding nothing a free account can reach are marked **Pro only**,
+  because the CLI's own refusal — `Location does not exist or is disabled` —
+  does not say which of the two it meant.
+
+  The chip appears only once the Windscribe app is running and logged in:
+  `windscribe-cli` is a client, and a client on its own has nothing to offer.
+  The panel says which half is missing.
+
+  `windscribe-cli` also refuses to run while another copy of itself is running,
+  and each bar instantiates the widget separately — so on a multi-monitor
+  desktop the copies collide with each other. Calls are serialised per instance
+  and retried when they lose the race, rather than being read as an answer.
+
+  Closes #10.
+
+### Changed
+
+- The warning shown before one tool's kill switch is torn down for another now
+  names that tool's own command. It was written in Mullvad's vocabulary, which
+  was the wrong advice on any other chip.
+
 ## 1.1.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   desktop the copies collide with each other. Calls are serialised per instance
   and retried when they lose the race, rather than being read as an answer.
 
+  A status the widget cannot read leaves the last reading on screen, flagged as
+  stale. Blanking it would drop the chip while a tunnel was up — taking the only
+  way to bring that tunnel down with it — and would report the firewall as off
+  at the one moment the widget has no idea whether traffic is flowing.
+
   Closes #10.
 
 ### Changed

--- a/Model.js
+++ b/Model.js
@@ -835,3 +835,435 @@ function mullvadToggleArgs(key, value) {
   if (key === "lan") return ["lan", "set", value ? "allow" : "block"]
   return []
 }
+
+// ------------------------------------------------------------- Windscribe
+
+// `windscribe-cli status` prints a plain-text block whose lines come and go
+// with the state — `Protocol` only appears while a tunnel is up:
+//
+//   Internet connectivity: available
+//   Login state: Logged in
+//   Firewall state: On
+//   Connect state: Connected: Zurich - Alphorn
+//   Protocol: WireGuard:443
+//   Data usage: 96.99 MB / 2.00 GB
+//   Update available: 2.23.11
+//
+// So this matches on the leading key rather than on line position. Two values
+// carry a colon of their own — `Connect state` and `Protocol` — which is why
+// the split is on the first one only.
+function parseWindscribeStatus(raw) {
+  var result = {
+    loaded: false,
+    loggedIn: false,
+    loginText: "",
+    online: true,
+    firewallKnown: false,
+    firewallOn: false,
+    firewallAlways: false,
+    state: "",
+    connected: false,
+    location: "",
+    city: "",
+    nickname: "",
+    protocol: "",
+    port: "",
+    dataUsed: "",
+    dataLimit: "",
+    interference: false,
+    error: "",
+    statusText: ""
+  }
+
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim()
+    if (line === "") continue
+
+    var separator = line.indexOf(":")
+    if (separator < 0) continue
+
+    var key = line.substring(0, separator).trim().toLowerCase()
+    var value = line.substring(separator + 1).trim()
+    if (value === "") continue
+
+    if (key === "login state") {
+      result.loginText = value
+      result.loggedIn = /^logged in/i.test(value)
+      result.loaded = true
+    } else if (key === "internet connectivity") {
+      result.online = !/^no|^unavailable|^not available/i.test(value)
+    } else if (key === "firewall state") {
+      // Three spellings, and only the two known ones are believed: reporting a
+      // kill switch as off while it is on is the one mistake worth ruling out.
+      var firewall = value.toLowerCase()
+      if (firewall === "off") {
+        result.firewallKnown = true
+      } else if (firewall === "on" || firewall === "always on") {
+        result.firewallKnown = true
+        result.firewallOn = true
+        result.firewallAlways = firewall === "always on"
+      }
+    } else if (key === "connect state") {
+      applyWindscribeConnectState(result, value)
+      result.loaded = true
+    } else if (key === "protocol") {
+      var protocol = value.split(":")
+      result.protocol = protocol[0].trim()
+      result.port = protocol.length > 1 ? protocol[1].trim() : ""
+    } else if (key === "data usage") {
+      var usage = value.split("/")
+      result.dataUsed = usage[0].trim()
+      result.dataLimit = usage.length > 1 ? usage[1].trim() : ""
+    }
+  }
+
+  result.statusText = windscribeStateText(result)
+  return result
+}
+
+// The value of `Connect state` is a sentence rather than an enum: "Connected:
+// Zurich - Alphorn", "Connecting", "Error: Location does not exist or is
+// disabled", or "Disconnected due to reaching WireGuard key limit. …".
+//
+// The error branch is not decoration. `windscribe-cli connect -n` exits 0 the
+// moment the daemon accepts the request, so a connect that fails seconds later
+// — a free account reaching for a Pro location, say — is reported here and
+// nowhere else. The state is sticky: it stays until something succeeds.
+function applyWindscribeConnectState(result, value) {
+  var text = String(value || "").trim()
+
+  // Appended to the connected state when the daemon sees the tunnel struggling.
+  var interference = text.match(/^(.*?)\s*\[Network interference\]$/i)
+  if (interference) {
+    result.interference = true
+    text = interference[1].trim()
+  }
+
+  var failure = text.match(/^error\s*:\s*(.+)$/i)
+  if (failure) {
+    result.state = "error"
+    result.error = failure[1].trim()
+    return
+  }
+
+  if (/^connecting\b/i.test(text)) {
+    result.state = "connecting"
+    applyWindscribeLocation(result, afterFirstColon(text))
+    return
+  }
+  if (/^connected\b/i.test(text)) {
+    result.state = "connected"
+    result.connected = true
+    applyWindscribeLocation(result, afterFirstColon(text))
+    return
+  }
+  if (/^disconnecting\b/i.test(text)) {
+    result.state = "disconnecting"
+    return
+  }
+  if (/^disconnected\b/i.test(text)) {
+    result.state = "disconnected"
+    // "Disconnected due to reaching WireGuard key limit. Use …" is a disconnect
+    // with a reason attached, and the reason is the half worth reading.
+    if (!/^disconnected$/i.test(text)) result.error = text
+  }
+}
+
+function afterFirstColon(text) {
+  var separator = String(text || "").indexOf(":")
+  return separator < 0 ? "" : text.substring(separator + 1).trim()
+}
+
+// `status` names the connected location as "City - Nickname", one segment
+// shorter than the three-part form `locations` prints, so the nickname is taken
+// from the end rather than from a fixed position.
+function applyWindscribeLocation(result, text) {
+  var location = String(text || "").trim()
+  if (location === "") return
+
+  result.location = location
+  var parts = location.split(" - ")
+  result.nickname = parts[parts.length - 1].trim()
+  if (parts.length > 1) result.city = parts[parts.length - 2].trim()
+}
+
+function windscribeStateText(status) {
+  if (!status.loaded) return "Unknown"
+  if (!status.loggedIn) return "Not logged in"
+  if (status.state === "connected") return "Connected"
+  if (status.state === "connecting") return "Connecting"
+  if (status.state === "disconnecting") return "Disconnecting"
+  if (status.state === "error") return "Not connected"
+  if (status.state === "disconnected") return "Disconnected"
+  return "Unknown"
+}
+
+function windscribeLocation(status) {
+  if (status.nickname !== "" && status.city !== "") return status.nickname + " · " + status.city
+  if (status.nickname !== "") return status.nickname
+  return status.city
+}
+
+function windscribeSummary(status) {
+  if (!status.loaded) return "Checking…"
+  if (!status.loggedIn) return "Not logged in"
+
+  if (status.state === "connected") {
+    var place = windscribeLocation(status)
+    var line = place !== "" ? place : "Connected"
+    return status.interference ? line + " · network interference" : line
+  }
+  if (status.state === "connecting") {
+    var target = windscribeLocation(status)
+    return target !== "" ? "Connecting to " + target + "…" : "Connecting…"
+  }
+  if (status.state === "disconnecting") return "Disconnecting…"
+  // The failure itself goes to lastError, which is where the panel puts the
+  // things a user has to act on; the summary only says where that leaves them.
+  if (status.state === "error") return status.firewallOn ? "Not connected · traffic blocked" : "Not connected"
+  if (status.state === "disconnected") return status.firewallOn ? "Not connected · traffic blocked" : "Not connected"
+  return "Checking…"
+}
+
+function windscribeDetails(status) {
+  if (status.state !== "connected") return []
+
+  var rows = [detail("Server", status.nickname), detail("Location", status.city)]
+  if (status.protocol !== "") {
+    rows.push(detail("Protocol", status.port !== "" ? status.protocol + " · " + status.port : status.protocol))
+  }
+  // Windscribe meters the free plan, and the number is only ever printed here.
+  if (status.dataUsed !== "") {
+    rows.push(detail("Data used", status.dataLimit !== "" ? status.dataUsed + " of " + status.dataLimit : status.dataUsed))
+  }
+  if (status.interference) rows.push(detail("Network", "Interference detected"))
+  return rows.filter(function(row) { return row.value !== "" })
+}
+
+// `windscribe-cli locations` prints one location per line:
+//
+//   Best Location - Alphorn (10 Gbps)
+//   US Central - Atlanta - Magic City (Pro) (10 Gbps)
+//   Switzerland - Zurich - Alphorn (10 Gbps)
+//
+// Region, city and nickname are joined with " - ", and the trailing groups
+// describe the entry rather than name it. Only the markers the CLI actually
+// prints are stripped, so a nickname that happens to end in brackets keeps
+// them.
+function parseWindscribeLocations(raw) {
+  var locations = []
+  var lines = String(raw || "").split("\n")
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim()
+    // `locations static` prefixes a device-name line and both variants say so
+    // when there is nothing to list.
+    if (line === "" || line === "No locations." || line.indexOf("(Device name:") === 0) continue
+
+    var pro = false
+    var disabled = false
+    var text = line
+
+    for (;;) {
+      var marker = text.match(/\s*\((Pro|Disabled|[^()]*Gbps)\)$/i)
+      if (marker) {
+        var name = marker[1].toLowerCase()
+        if (name === "pro") pro = true
+        else if (name === "disabled") disabled = true
+        text = text.substring(0, text.length - marker[0].length)
+        continue
+      }
+      // The CLI puts a static IP's device name in brackets.
+      var bracket = text.match(/\s*\[[^\[\]]*\]$/)
+      if (!bracket) break
+      text = text.substring(0, text.length - bracket[0].length)
+    }
+
+    var parts = text.split(" - ")
+    for (var p = 0; p < parts.length; p++) parts[p] = parts[p].trim()
+
+    var nickname = parts[parts.length - 1]
+    if (nickname === "") continue
+
+    locations.push({
+      region: parts.length > 1 ? parts[0] : "",
+      city: parts.length > 2 ? parts.slice(1, parts.length - 1).join(" - ") : "",
+      nickname: nickname,
+      pro: pro,
+      disabled: disabled
+    })
+  }
+  return locations
+}
+
+// The first row is the pseudo-location the daemon resolves "best" to. It names
+// a server rather than a place, so it belongs on the quick row and not in the
+// region list.
+function isWindscribeBestRow(location) {
+  return String(location.region || "").toLowerCase() === "best location"
+}
+
+function windscribeBestNickname(locations) {
+  for (var i = 0; i < locations.length; i++) {
+    if (isWindscribeBestRow(locations[i])) return locations[i].nickname
+  }
+  return ""
+}
+
+// Windscribe's own top-level grouping — a country most of the time, a slice of
+// one ("US East") where a country has too many. `connect` takes a region name
+// directly, so the row needs nothing beyond its name to be connectable, and
+// the daemon picks a datacenter inside it.
+function windscribeRegions(locations) {
+  var regions = []
+  var index = {}
+
+  for (var i = 0; i < locations.length; i++) {
+    var location = locations[i]
+    if (isWindscribeBestRow(location) || location.disabled || location.region === "") continue
+
+    var key = location.region.toLowerCase()
+    var region = index[key]
+    if (!region) {
+      region = { name: location.region, cities: [], nicknames: [], free: 0, total: 0 }
+      index[key] = region
+      regions.push(region)
+    }
+
+    if (location.city !== "" && region.cities.indexOf(location.city) < 0) region.cities.push(location.city)
+    region.nicknames.push(location.nickname)
+    region.total += 1
+    if (!location.pro) region.free += 1
+  }
+  return regions
+}
+
+// A free account cannot reach a Pro location, and the CLI's refusal — "Location
+// does not exist or is disabled" — does not say which of the two it meant. Say
+// it on the row instead of letting the connect fail to explain itself.
+function windscribeRegionDetail(region) {
+  var parts = []
+  if (region.cities.length > 0) {
+    parts.push(region.cities.length + (region.cities.length === 1 ? " city" : " cities"))
+  }
+  if (region.free === 0) parts.push("Pro only")
+  return parts.join(" · ")
+}
+
+// Windscribe names its regions and never prints a country code, so the
+// favorites setting is matched by name — "Switzerland" — and by leading word,
+// which is what makes "US" pick up US East, US Central and US West.
+function isWindscribeFavorite(name, favorites) {
+  if (!favorites || favorites.length === 0) return false
+
+  var region = String(name || "").toUpperCase()
+  var head = region.split(" ")[0]
+  for (var i = 0; i < favorites.length; i++) {
+    if (favorites[i] === region || favorites[i] === head) return true
+  }
+  return false
+}
+
+// `connect` with no location reuses the last one, which is the same row the
+// user just clicked; "best" is the only quick answer worth its own row.
+function windscribeQuickTargets(bestNickname) {
+  var nickname = String(bestNickname || "")
+  return [
+    {
+      key: "best",
+      label: "Best location",
+      detail: nickname !== "" ? "Currently " + nickname : "Let Windscribe pick",
+      glyph: GLYPH_BOLT,
+      args: ["best"]
+    }
+  ]
+}
+
+function windscribeRegionTargets(regions, favorites, filter) {
+  var needle = String(filter || "").trim().toLowerCase()
+  var favored = []
+  var rest = []
+
+  for (var i = 0; i < regions.length; i++) {
+    var region = regions[i]
+    if (needle !== "") {
+      // Nicknames are in the haystack because they are what the CLI reports
+      // back while connected, so "alphorn" finds the row it will tick.
+      var haystack = (region.name + " " + region.cities.join(" ") + " "
+        + region.nicknames.join(" ")).toLowerCase()
+      if (haystack.indexOf(needle) < 0) continue
+    }
+
+    var target = {
+      key: "region:" + region.name.toLowerCase(),
+      label: region.name,
+      detail: windscribeRegionDetail(region),
+      glyph: GLYPH_VPN,
+      args: [region.name]
+    }
+    if (needle === "" && isWindscribeFavorite(region.name, favorites)) favored.push(target)
+    else rest.push(target)
+  }
+
+  return favored.concat(rest)
+}
+
+// The status line names a city and a nickname but never the region, so the row
+// to tick is found by looking the connected server back up in the list. City
+// first, across every region, because a nickname is a joke and a city is not:
+// two regions sharing a nickname is likelier than two sharing a city.
+function windscribeCurrentKey(status, regions) {
+  if (status.state !== "connected" && status.state !== "connecting") return ""
+
+  var city = String(status.city || "").toLowerCase()
+  var nickname = String(status.nickname || "").toLowerCase()
+  var i = 0
+  var n = 0
+
+  if (city !== "") {
+    for (i = 0; i < regions.length; i++) {
+      for (n = 0; n < regions[i].cities.length; n++) {
+        if (regions[i].cities[n].toLowerCase() === city) return "region:" + regions[i].name.toLowerCase()
+      }
+    }
+  }
+  if (nickname !== "") {
+    for (i = 0; i < regions.length; i++) {
+      for (n = 0; n < regions[i].nicknames.length; n++) {
+        if (regions[i].nicknames[n].toLowerCase() === nickname) return "region:" + regions[i].name.toLowerCase()
+      }
+    }
+  }
+  return ""
+}
+
+// One switchable setting: the firewall, which is Windscribe's kill switch.
+// Everything else lives in the desktop app's preferences file, which this
+// widget reads nothing from and writes nothing to.
+function windscribeToggles(status) {
+  if (!status || !status.firewallKnown) return []
+
+  return [
+    toggle("firewall", "Firewall",
+      status.firewallAlways
+        ? "Always on — change it in the Windscribe app"
+        : "Block traffic outside the tunnel",
+      status.firewallOn)
+  ]
+}
+
+function windscribeToggleArgs(key, value) {
+  if (key === "firewall") return ["firewall", value ? "on" : "off"]
+  return []
+}
+
+// `windscribe-cli` holds a lock for as long as it runs, and a second
+// invocation does not wait its turn: it prints this and exits without doing
+// the work. The backend serialises its own calls, so seeing it means something
+// outside the widget is talking to the app — the user at a terminal, or the
+// desktop client. It is not an answer about the tunnel, and nothing should be
+// concluded from it.
+function isWindscribeCliLocked(text) {
+  return /already running/i.test(String(text || ""))
+}

--- a/Model.js
+++ b/Model.js
@@ -1122,6 +1122,11 @@ function windscribeRegions(locations) {
   for (var i = 0; i < locations.length; i++) {
     var location = locations[i]
     if (isWindscribeBestRow(location) || location.disabled || location.region === "") continue
+    // The name is handed to `windscribe-cli connect` as an argument. No shell is
+    // involved, so there is nothing to inject, but a name starting with a dash
+    // would be read as an option rather than as a place. No such region exists;
+    // a row that claimed to be one would not be a region either.
+    if (location.region.charAt(0) === "-") continue
 
     var key = location.region.toLowerCase()
     var region = index[key]
@@ -1261,9 +1266,101 @@ function windscribeToggleArgs(key, value) {
 // `windscribe-cli` holds a lock for as long as it runs, and a second
 // invocation does not wait its turn: it prints this and exits without doing
 // the work. The backend serialises its own calls, so seeing it means something
-// outside the widget is talking to the app — the user at a terminal, or the
-// desktop client. It is not an answer about the tunnel, and nothing should be
-// concluded from it.
+// outside the widget is talking to the app — the user at a terminal, or this
+// same widget on another monitor, since each bar instantiates it separately.
+// It is not an answer about the tunnel, and nothing should be concluded from
+// it.
 function isWindscribeCliLocked(text) {
   return /already running/i.test(String(text || ""))
+}
+
+// The firewall is a kill switch, and `lockdownMode` is read to decide whether
+// to warn someone that switching tools will not get through. "The tool never
+// said" has to weigh the same as "the tool said yes": the cost of a warning
+// nobody needed is a sentence, and the cost of the missing one is a connect
+// that fails for reasons the panel had already been told about and forgot.
+//
+// The summary line deliberately does not use this — it states what the tool
+// reported, and an unrecognised firewall line is not a report that traffic is
+// blocked. One weighs a risk, the other states a fact.
+function windscribeBlocksWhileDown(status) {
+  if (!status || !status.loaded) return false
+  return status.firewallOn || !status.firewallKnown
+}
+
+// --------------------------------------------------- Windscribe call queue
+//
+// Because two `windscribe-cli` invocations may not overlap, every call the
+// backend makes is a job in a queue of one runner. The rules are here rather
+// than in the QML so they can be tested: this is a reducer over (queue,
+// running job), not process plumbing, and it is the part that has been wrong.
+
+var WINDSCRIBE_MAX_ATTEMPTS = 4
+
+// Reads answer a question; actions change something. That is the whole
+// difference the queue cares about.
+function isWindscribeReadJob(kind) {
+  return kind === "status" || kind === "locations"
+}
+
+// Reads are idempotent, so a second one waiting behind the first is a stale
+// answer nobody asked for: the poll fires faster than the CLI replies, and a
+// backlog of them would keep the panel a cycle behind for as long as the shell
+// ran. A click goes to the front, because waiting out a two-hundred line
+// location fetch is not what "connect" should feel like.
+//
+// Returns the queue unchanged when the job is a duplicate read.
+function windscribeEnqueue(queue, runningKind, kind, args) {
+  var next = queue.slice()
+  var job = { kind: kind, args: args, attempts: 0 }
+
+  if (!isWindscribeReadJob(kind)) {
+    next.unshift(job)
+    return next
+  }
+
+  if (runningKind === kind) return queue
+  for (var i = 0; i < next.length; i++) {
+    if (next[i].kind === kind) return queue
+  }
+  next.push(job)
+  return next
+}
+
+// A job that lost the lock goes back to the head of its own queue, one attempt
+// older. A fresh object rather than a mutated one, so nothing that captured the
+// old job sees its attempt count move underneath it.
+function windscribeRequeue(queue, job) {
+  var next = queue.slice()
+  next.unshift({ kind: job.kind, args: job.args, attempts: job.attempts + 1 })
+  return next
+}
+
+// Bounded, because a lock held by something that is never going to let go is
+// not worth knocking on forever. Past the last attempt the job runs its
+// finisher, which treats a refusal as inconclusive rather than as news.
+function windscribeCanRetry(job) {
+  return !!job && job.attempts < WINDSCRIBE_MAX_ATTEMPTS
+}
+
+// The jitter is not decoration. Two widget instances that started together lose
+// together — that is what a shared lock and a shared poll interval do — and
+// backing off by the same amount would have them collide again on every round.
+// Something has to break the tie, and the attempt count cannot: it is identical
+// on both sides. `roll` is a 0..1 draw, passed in so this stays testable.
+function windscribeRetryDelay(attempts, roll) {
+  var draw = Number(roll)
+  if (!isFinite(draw) || draw < 0) draw = 0
+  if (draw > 1) draw = 1
+  return 120 * attempts + Math.floor(draw * 280)
+}
+
+// Whether a job of any of these kinds is running or waiting — what stops a
+// second click landing on top of the first.
+function windscribePending(queue, runningKind, kinds) {
+  if (kinds.indexOf(runningKind) >= 0) return true
+  for (var i = 0; i < queue.length; i++) {
+    if (kinds.indexOf(queue[i].kind) >= 0) return true
+  }
+  return false
 }

--- a/MullvadBackend.qml
+++ b/MullvadBackend.qml
@@ -36,6 +36,7 @@ Item {
   readonly property bool lockdownMode: daemonSettings.seen !== undefined
     && daemonSettings.seen.lockdown === true
     && daemonSettings.lockdown
+  readonly property string lockdownHint: "mullvad lockdown-mode set off"
 
   // Switches the panel draws under the detail rows. Values are whatever the
   // daemon last reported; the widget stores none of them.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ A VPN widget for the Omarchy bar. One icon shows whether you are behind a
 tunnel; one panel connects, disconnects, and switches between the VPN tools you
 actually have installed.
 
-It supports **Proton VPN**, **Mullvad**, and the **OpenVPN** and **WireGuard**
-profiles NetworkManager holds. Only the tools
+It supports **Proton VPN**, **Mullvad**, **Windscribe**, and the **OpenVPN** and
+**WireGuard** profiles NetworkManager holds. Only the tools
 that have something to offer appear — install none and the widget tells you so;
 have several and a chip row lets you switch between them.
 
 <img src="preview.png" alt="The VPN panel open in the Omarchy bar, showing a Proton VPN connection to Zurich and a country list" width="365">
 
 Each installed tool gets its own chip and its own view — Proton VPN above,
-[Mullvad](#mullvad) and [NetworkManager](#networkmanager-profiles) below.
+[Mullvad](#mullvad), [Windscribe](#windscribe) and
+[NetworkManager](#networkmanager-profiles) below.
 
 ## Install
 
@@ -60,15 +61,16 @@ Inside the panel:
   chevron; click the row to fold them out, click it again to put them away. It
   starts closed and stays however you left it until the shell restarts.
 - **The settings** inside are Mullvad's connect-on-startup, lockdown mode, and
-  local network sharing, and Proton VPN's kill switch, NetShield, and port
-  forwarding. They show what the tool itself reports, so changing one from its
-  CLI shows up here on the next poll — the widget keeps no copy and never puts
-  one back for you.
+  local network sharing, Proton VPN's kill switch, NetShield, and port
+  forwarding, and Windscribe's firewall. They show what the tool itself reports,
+  so changing one from its CLI shows up here on the next poll — the widget keeps
+  no copy and never puts one back for you.
 - **The list** is what you can connect to: for Proton VPN, fastest / P2P /
   random / Secure Core followed by every country; for Mullvad, any location
-  followed by every country it has relays in; for NetworkManager, your OpenVPN
-  and WireGuard profiles, told apart by their icon. A check mark marks where you
-  are connected.
+  followed by every country it has relays in; for Windscribe, best location
+  followed by every region it serves; for NetworkManager, your OpenVPN and
+  WireGuard profiles, told apart by their icon. A check mark marks where you are
+  connected.
 
 Keyboard, once the panel is open: `j`/`k` or arrows move — through the header,
 the chips, the name row, the settings switches if they are open, then the list —
@@ -87,6 +89,8 @@ Omarchy with its Quickshell desktop, plus at least one of:
 - **Proton VPN** — the `protonvpn` CLI, signed in (`protonvpn signin`).
 - **Mullvad** — the `mullvad` CLI with `mullvad-daemon` running, logged in
   (`mullvad account login <number>`).
+- **Windscribe** — `windscribe-cli` with the Windscribe app running, logged in
+  (`windscribe-cli login`).
 - **OpenVPN or WireGuard** — `nmcli`, plus `openvpn` or `wg` (wireguard-tools),
   with at least one profile imported into NetworkManager.
 
@@ -99,8 +103,8 @@ Configure these in **Setup › Plugins**, or in the widget's entry in
 |---------|---------|--------------|
 | `refreshIntervalSec` | `15` | How often the connection status is polled |
 | `preferredBackend` | `Auto` | Which tool the panel opens on. `Auto` picks whichever is connected |
-| `favoriteCountries` | `CH,NL,US` | Country codes pinned to the top of the Proton VPN and Mullvad lists |
-| `hiddenBackends` | *(empty)* | Tools the widget ignores entirely: `proton`, `mullvad`, `networkmanager`. The gear inside the panel writes this |
+| `favoriteCountries` | `CH,NL,US` | Country codes pinned to the top of the Proton VPN and Mullvad lists. Windscribe has no codes, so it matches names instead — see below |
+| `hiddenBackends` | *(empty)* | Tools the widget ignores entirely: `proton`, `mullvad`, `windscribe`, `networkmanager`. The gear inside the panel writes this |
 
 ## Mullvad
 
@@ -124,6 +128,45 @@ own. That switch is in the panel, or:
 ```bash
 mullvad lockdown-mode set off
 ```
+
+## Windscribe
+
+`windscribe-cli` is a client for the Windscribe desktop app, so the chip appears
+only once that app is running and logged in. Until then the panel says which of
+the two is missing instead of listing an empty chip.
+
+The list is Windscribe's own regions — a country most of the time, a slice of one
+where a country has too many (`US East`, `US West`). Clicking one connects to a
+datacenter inside it. **Best location** hands the choice back to Windscribe, and
+names the server it currently resolves to. Cities and Windscribe's server
+nicknames are searchable even though only regions are listed, so both `zurich`
+and `alphorn` find Switzerland.
+
+Rows marked **Pro only** hold nothing a free account can reach. Connecting to one
+fails with `Location does not exist or is disabled`, which does not say which of
+the two it meant — hence the marker.
+
+Because Windscribe names its regions and never prints a country code,
+`favoriteCountries` matches them by name (`Switzerland`) and by leading word
+(`US` pins US East, US Central and US West). The default `CH,NL,US` therefore
+pins only the US rows on this chip.
+
+**The firewall** is Windscribe's kill switch, and with the app's firewall mode set
+to `Auto` it turns itself on before a connect and off after a disconnect. While it
+is on and the tunnel is down, nothing leaves the machine — including the traffic
+another VPN needs to connect. The widget says so before it shuts Windscribe down
+for a different tool, but it will not turn the firewall off on its own. That
+switch is in the panel, or:
+
+```bash
+windscribe-cli firewall off
+```
+
+One caveat that is Windscribe's and not the widget's: `windscribe-cli` refuses to
+run while another copy of itself is running, exiting with `Windscribe CLI is
+already running` rather than waiting its turn. The widget serialises its own calls
+and retries the ones that lose the race, so a command you run yourself at a
+terminal costs the panel a moment and nothing more.
 
 ## NetworkManager profiles
 
@@ -194,6 +237,10 @@ is the one saying no.
 the daemon with `sudo systemctl start mullvad-daemon` (and `enable` it to have it
 come back after a reboot).
 
+**Windscribe is installed but has no chip.** `windscribe-cli` is a client too.
+The panel says which half is missing — start the Windscribe app, or
+`windscribe-cli login` — and picks the chip up on the next refresh.
+
 **Nothing appears in the bar.** Confirm the plugin is enabled with
 `omarchy plugin list`, then `omarchy restart shell`.
 
@@ -209,9 +256,9 @@ it:
 ```bash
 omarchy-shell jkoestinger.vpn status       # "Proton VPN · CH#1129 · Zurich, Switzerland"
 omarchy-shell jkoestinger.vpn ip           # current public address
-omarchy-shell jkoestinger.vpn backends     # "proton mullvad networkmanager"
+omarchy-shell jkoestinger.vpn backends     # "proton mullvad windscribe networkmanager"
 omarchy-shell jkoestinger.vpn use mullvad  # switch the panel's active tool
-omarchy-shell jkoestinger.vpn connect CH   # country code, profile name, or row key
+omarchy-shell jkoestinger.vpn connect CH   # country code, region or profile name, or row key
 omarchy-shell jkoestinger.vpn quickconnect # each tool's default connection
 omarchy-shell jkoestinger.vpn disconnect
 omarchy-shell jkoestinger.vpn toggle       # open or close the panel

--- a/VpnController.qml
+++ b/VpnController.qml
@@ -8,6 +8,8 @@ import "Model.js" as Model
 // Backend contract (duck-typed — a backend is any Item exposing these):
 //
 //   backendId, label, glyph          identity for the switcher chips
+//   lockdownMode, lockdownHint       optional: this tool blocks all traffic
+//                                    while it is down, and how to stop it
 //   supportsFilter, filterPlaceholder whether the panel shows its filter field
 //   filter                           panel writes the current filter text here
 //   detected                         tool is installed and has something to offer
@@ -32,7 +34,7 @@ Item {
   // Set when the user picks a chip; "" follows `preferredBackend`.
   property string selectedId: ""
 
-  readonly property var backends: [proton, mullvad, networkManager]
+  readonly property var backends: [proton, mullvad, windscribe, networkManager]
   // Tools this machine has. Hiding one is a statement about the widget, not
   // about the machine, so the settings view lists these — including the hidden
   // ones, which would otherwise be unreachable once they were switched off.
@@ -181,6 +183,7 @@ Item {
     var preferred = String(setting("preferredBackend", "Auto"))
     if (preferred === "Proton VPN") return "proton"
     if (preferred === "Mullvad") return "mullvad"
+    if (preferred === "Windscribe") return "windscribe"
     if (preferred === "NetworkManager") return "networkmanager"
     return ""
   }
@@ -264,12 +267,16 @@ Item {
     }
 
     for (var i = 0; i < others.length; i++) {
-      // Mullvad's lockdown mode drops all traffic the moment its tunnel goes
-      // down, which is exactly when the incoming connect needs the network.
-      // Say so up front rather than let it fail as a timeout.
+      // Mullvad's lockdown mode and Windscribe's firewall both drop all traffic
+      // the moment their tunnel goes down, which is exactly when the incoming
+      // connect needs the network. Say so up front rather than let it fail as a
+      // timeout. The command to undo it is the backend's to name — a backend
+      // that offers no hint still gets the warning.
       if (others[i].lockdownMode === true) {
+        var undo = String(others[i].lockdownHint || "")
         setNotice(others[i].label + " blocks all traffic while it is disconnected, "
-          + "so connecting will not get through. Turn it off with: mullvad lockdown-mode set off")
+          + "so connecting will not get through."
+          + (undo !== "" ? " Turn it off with: " + undo : ""))
       }
       others[i].disconnect()
     }
@@ -346,6 +353,11 @@ Item {
 
   MullvadBackend {
     id: mullvad
+    settings: root.settings
+  }
+
+  WindscribeBackend {
+    id: windscribe
     settings: root.settings
   }
 

--- a/WindscribeBackend.qml
+++ b/WindscribeBackend.qml
@@ -1,0 +1,489 @@
+import QtQuick
+import Quickshell.Io
+import "Model.js" as Model
+
+// Windscribe backend, driven by the `windscribe-cli` client talking to the
+// Windscribe desktop app. Implements the backend contract documented in
+// VpnController.qml.
+//
+// Three things make this one different from the other backends.
+//
+// The CLI takes a global lock, so no two invocations may overlap — every call
+// goes through one queue and one process. See enqueue().
+//
+// Being installed is not being usable: the CLI is a client for an app you have
+// to be logged into, so `detected` waits on the login state and not on the
+// binary.
+//
+// And `connect` is run non-blocking, so it exits 0 the moment the request is
+// accepted. The outcome arrives later, in the status line, and until it does a
+// failure looks exactly like a success.
+Item {
+  id: root
+  visible: false
+
+  property var settings: ({})
+  property string filter: ""
+
+  readonly property string backendId: "windscribe"
+  readonly property string label: "Windscribe"
+  readonly property string glyph: Model.GLYPH_VPN
+  readonly property bool supportsFilter: true
+  // Cities and server nicknames match too, but the field is only so wide.
+  readonly property string filterPlaceholder: "Filter locations — press / to search"
+
+  property var status: Model.parseWindscribeStatus("")
+  property var locations: []
+  property bool locationsLoaded: false
+  property string actionStatus: ""
+  property string lastError: ""
+
+  property bool _present: false
+  property bool _probed: false
+  // The app is not answering — installed, but nothing behind the socket.
+  property bool _statusFailed: false
+
+  // The binary alone says nothing: `windscribe-cli` is a client, and a client
+  // nobody is logged into has no locations to offer and cannot connect. The
+  // panel would otherwise draw a chip leading to an empty list.
+  readonly property bool detected: _present && status.loggedIn
+
+  readonly property string setupHint: {
+    if (!_present) return ""
+    if (_statusFailed) return "Windscribe is installed but its app is not answering. Start Windscribe, then reopen this panel."
+    if (status.loaded && !status.loggedIn) return "Windscribe is installed but not logged in. Log in with: windscribe-cli login"
+    return ""
+  }
+
+  // Windscribe's firewall is a kill switch: while it is on and the tunnel is
+  // down, nothing leaves the machine at all — including the traffic another
+  // backend's connect needs.
+  readonly property bool lockdownMode: detected && status.firewallOn && !connected
+  readonly property string lockdownHint: "windscribe-cli firewall off"
+
+  // The one setting the CLI can change. Its value is always what the app last
+  // reported; the widget stores no copy.
+  readonly property var toggles: Model.applyPendingToggles(Model.windscribeToggles(status), _pendingToggles)
+  property var _pendingToggles: ({})
+  // Which switch is in flight, so a refusal rolls back the right one.
+  property string _toggleKey: ""
+
+  // Optimistic connection state so the switch flips the instant you click it.
+  // -1 follows the app, 0/1 while a connect/disconnect is still in flight.
+  property int _desired: -1
+
+  readonly property bool connected: _desired === -1 ? status.connected : (_desired === 1)
+  readonly property bool busy: _running !== "" || _queue.length > 0
+  readonly property string summary: Model.windscribeSummary(status)
+  readonly property var details: Model.windscribeDetails(status)
+  readonly property var regions: Model.windscribeRegions(locations)
+  readonly property var favorites: Model.favoriteCodes(setting("favoriteCountries", "CH,NL,US"))
+  readonly property string emptyText: locationsLoaded ? "No locations match." : "Loading locations…"
+  readonly property string currentKey: Model.windscribeCurrentKey(status, regions)
+  readonly property var targets: filter === ""
+    ? Model.windscribeQuickTargets(Model.windscribeBestNickname(locations))
+        .concat(Model.windscribeRegionTargets(regions, favorites, ""))
+    : Model.windscribeRegionTargets(regions, favorites, filter)
+
+  function setting(name, fallback) {
+    var value = settings ? settings[name] : undefined
+    return value === undefined || value === null ? fallback : value
+  }
+
+  // ------------------------------------------------------------- the queue
+  //
+  // `windscribe-cli` holds a lock for as long as it runs. A second invocation
+  // does not wait its turn and does not do the work — it exits saying
+  // "Windscribe CLI is already running" and nothing else. Two calls started
+  // together lose both answers, so a backend that polled status while fetching
+  // locations would spend its life reading failures and hiding itself.
+  //
+  // So: one process, and one job at a time.
+  //
+  // That is only half of it. The lock is per machine and the widget is
+  // instantiated once per monitor, so on a two-screen desktop there are two of
+  // these queues, each disciplined and each unaware of the other. Ordering
+  // within one instance is not enough — see the retry in onExited.
+  property var _queue: []
+  property string _running: ""
+  property var _current: null
+
+  readonly property bool _actionPending: {
+    if (_running === "connect" || _running === "disconnect") return true
+    for (var i = 0; i < _queue.length; i++) {
+      if (_queue[i].kind === "connect" || _queue[i].kind === "disconnect") return true
+    }
+    return false
+  }
+
+  readonly property bool _togglePending: {
+    if (_running === "toggle") return true
+    for (var i = 0; i < _queue.length; i++) {
+      if (_queue[i].kind === "toggle") return true
+    }
+    return false
+  }
+
+  // Reads are idempotent, so a second one waiting behind the first is a stale
+  // answer nobody asked for: the poll fires faster than the CLI replies, and a
+  // backlog of them would keep the panel a cycle behind for as long as the
+  // shell ran. A click goes to the front, because waiting out a two-hundred
+  // line location fetch is not what "connect" should feel like.
+  function enqueue(kind, args) {
+    if (kind === "status" || kind === "locations") {
+      if (_running === kind) return
+      for (var i = 0; i < _queue.length; i++) {
+        if (_queue[i].kind === kind) return
+      }
+    }
+
+    var queue = _queue.slice()
+    var job = { kind: kind, args: args, attempts: 0 }
+    if (kind === "status" || kind === "locations") queue.push(job)
+    else queue.unshift(job)
+    _queue = queue
+    pump()
+  }
+
+  // Put a job that lost the lock back at the head of its own queue. Bounded,
+  // because a lock held by something that is never going to let go is not
+  // something to keep knocking on: past the last attempt the job runs its
+  // finisher, which treats the refusal as inconclusive rather than as news.
+  function retry(job) {
+    if (job.attempts >= 4) return false
+
+    job.attempts += 1
+    var queue = _queue.slice()
+    queue.unshift(job)
+    _queue = queue
+
+    // The jitter is not decoration. Two instances that started together lose
+    // together — that is what a shared lock and a shared poll interval do — and
+    // backing off by the same amount would have them collide again on every
+    // round. Something has to break the tie, and the attempt count cannot: it
+    // is identical on both sides.
+    retryTimer.interval = 120 * job.attempts + Math.floor(Math.random() * 280)
+    retryTimer.restart()
+    return true
+  }
+
+  Timer {
+    id: retryTimer
+    interval: 200
+    repeat: false
+    onTriggered: root.pump()
+  }
+
+  function pump() {
+    if (_running !== "" || _queue.length === 0) return
+    // The bookkeeping is cleared in onExited, which can run a moment before the
+    // process itself reports finished. Come back rather than drop the job: the
+    // queue is only pumped on an enqueue otherwise, and the next one may be a
+    // poll interval away.
+    if (cliProcess.running) {
+      pumpTimer.restart()
+      return
+    }
+
+    var queue = _queue.slice()
+    var job = queue.shift()
+    _queue = queue
+    _current = job
+    _running = job.kind
+    cliProcess.command = ["windscribe-cli"].concat(job.args)
+    cliProcess.running = true
+    stallTimer.restart()
+  }
+
+  // Starting the next job from inside onExited would re-enter the process that
+  // is still finishing, the same reason the other backends hop through a timer
+  // to chain their two-step connects.
+  Timer {
+    id: pumpTimer
+    interval: 0
+    repeat: false
+    onTriggered: root.pump()
+  }
+
+  // One job at a time only works while every job ends. A process that never
+  // reports back would leave `_running` set forever, and since a read already
+  // in flight is never queued twice, the backend would stop asking about the
+  // tunnel for as long as the shell ran and quietly present its last reading as
+  // current. Nothing this CLI does takes half a minute, so past that the job is
+  // written off. `pump` still refuses to start while the process object says it
+  // is running, so writing it off cannot put two of them on the lock.
+  Timer {
+    id: stallTimer
+    interval: 30000
+    repeat: false
+    onTriggered: {
+      root._running = ""
+      root._current = null
+      root.pump()
+    }
+  }
+
+  // ------------------------------------------------------------ the verbs
+
+  // Probing, and one status read, because the login state is the other half of
+  // the answer to "is this tool here". Both are asked once: binaries do not
+  // come and go while the shell runs, and `force` is the user asking again —
+  // see refreshAll() in VpnController.
+  function detect(force) {
+    if (presenceProbe.running) return
+    if (_probed && force !== true) return
+    presenceProbe.running = true
+  }
+
+  // Two hundred locations is a lot to fetch for a tool the user switched off,
+  // and a hidden backend is given detect() alone. So the list is only ever
+  // asked for on a path that started here.
+  property bool _wantLocations: false
+
+  function refresh() {
+    if (!_present) return
+    _wantLocations = true
+    enqueue("status", ["status"])
+    loadLocations()
+  }
+
+  function loadLocations() {
+    if (!_wantLocations || !detected || locationsLoaded) return
+    enqueue("locations", ["locations"])
+  }
+
+  function setToggle(key, value) {
+    if (!detected || _togglePending) return
+
+    var args = Model.windscribeToggleArgs(key, value)
+    if (args.length === 0) return
+
+    var pending = {}
+    for (var name in _pendingToggles) pending[name] = _pendingToggles[name]
+    pending[key] = value
+    _pendingToggles = pending
+
+    lastError = ""
+    _toggleKey = key
+    enqueue("toggle", args)
+    pendingTimer.restart()
+  }
+
+  function clearPending(key) {
+    var pending = {}
+    for (var name in _pendingToggles) {
+      if (name !== key) pending[name] = _pendingToggles[name]
+    }
+    _pendingToggles = pending
+  }
+
+  // `-n` returns as soon as the daemon accepts the request instead of blocking
+  // for the length of the handshake. A blocking call would hold the CLI lock —
+  // and with it every status read — for the five or ten seconds the tunnel
+  // takes to come up, which is exactly the stretch the panel has something to
+  // say. The settle timer polls for the outcome instead.
+  function connectTo(target) {
+    if (!detected || _actionPending || !target) return
+    _desired = 1
+    lastError = ""
+    actionStatus = "Connecting to " + target.label + "…"
+    enqueue("connect", ["connect", "-n"].concat(target.args || []))
+  }
+
+  function disconnect() {
+    if (!detected || _actionPending) return
+    _desired = 0
+    lastError = ""
+    actionStatus = "Disconnecting…"
+    enqueue("disconnect", ["disconnect", "-n"])
+  }
+
+  function toggleConnection() {
+    if (connected) disconnect()
+    else connectTo({ label: "the best location", args: ["best"] })
+  }
+
+  // ------------------------------------------------------------- the state
+
+  function applyStatus(raw) {
+    var parsed = Model.parseWindscribeStatus(raw)
+    root.status = parsed
+
+    // An accepted-then-failed connect is reported nowhere but here, so the
+    // optimistic switch has to be dropped on sight of it. Left alone it would
+    // stay on "connected" until the settle timer gave up, which is the widget
+    // vouching for a tunnel that never came up.
+    if (parsed.state === "error") root._desired = -1
+    else if (root._desired !== -1 && parsed.connected === (root._desired === 1)) root._desired = -1
+
+    // The CLI's error state is sticky — it stands until the next successful
+    // connect — so this both raises the failure and clears it, rather than
+    // only ever raising it.
+    root.lastError = parsed.error !== "" ? Model.elide(parsed.error, 140) : ""
+
+    root.reconcileToggles(parsed)
+    root.loadLocations()
+  }
+
+  // Drop the optimistic value only for the keys the app has since agreed with,
+  // so a poll landing mid-flight cannot flick another switch back.
+  function reconcileToggles(parsed) {
+    var current = Model.windscribeToggles(parsed)
+    var pending = {}
+    var changed = false
+
+    for (var key in _pendingToggles) {
+      var agreed = false
+      for (var i = 0; i < current.length; i++) {
+        if (current[i].key === key && current[i].value === _pendingToggles[key]) agreed = true
+      }
+      if (agreed) changed = true
+      else pending[key] = _pendingToggles[key]
+    }
+    if (changed) _pendingToggles = pending
+  }
+
+  // A command that exits clean but does not take would otherwise leave the
+  // switch showing the position the user asked for, marked busy, for as long as
+  // the panel is open. Optimism gets a deadline.
+  Timer {
+    id: pendingTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (Object.keys(root._pendingToggles).length === 0) return
+      root._pendingToggles = ({})
+      root.lastError = "Windscribe did not apply that setting."
+    }
+  }
+
+  // Longer than the other backends': `connect -n` hands back control before the
+  // tunnel exists, and a Windscribe handshake takes several seconds. Giving up
+  // early would drop the optimistic state onto a status that is still catching
+  // up and flick the switch back under a connect that is going to succeed.
+  Timer {
+    id: settleTimer
+    property int ticks: 0
+    interval: 1500
+    repeat: true
+    running: false
+    onTriggered: {
+      settleTimer.ticks += 1
+      root.refresh()
+      if (settleTimer.ticks >= 8) {
+        settleTimer.ticks = 0
+        settleTimer.running = false
+        root._desired = -1
+      }
+    }
+  }
+
+  // ---------------------------------------------------------- the processes
+
+  // The only call that does not go through the queue, because it is not the
+  // Windscribe CLI: `omarchy-cmd-present` takes no lock and answers instantly.
+  Process {
+    id: presenceProbe
+    command: ["omarchy-cmd-present", "windscribe-cli"]
+    running: true
+    onExited: function(exitCode) {
+      root._probed = true
+      root._present = exitCode === 0
+      // Login state takes a second command. Not refresh(): that would fetch the
+      // location list for a tool the user may have hidden.
+      if (root._present) root.enqueue("status", ["status"])
+    }
+  }
+
+  Process {
+    id: cliProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: cliStdout; waitForEnd: true }
+    stderr: StdioCollector { id: cliStderr; waitForEnd: true }
+    onExited: function(exitCode) {
+      var job = root._current
+      var kind = root._running
+      var out = String(cliStdout.text || "")
+      var err = String(cliStderr.text || "")
+
+      stallTimer.stop()
+      root._running = ""
+      root._current = null
+
+      // Somebody else had the lock. Nothing was read and nothing was done, so
+      // this is not a result to act on — ask again in a moment. Usually the
+      // somebody is this same widget on another monitor.
+      if (job && root.cliLocked(out, err) && root.retry(job)) return
+
+      if (kind === "status") root.finishStatus(exitCode, out, err)
+      else if (kind === "locations") root.finishLocations(exitCode, out)
+      else if (kind === "toggle") root.finishToggle(exitCode, out, err)
+      else if (kind !== "") root.finishAction(exitCode, out, err)
+
+      pumpTimer.restart()
+    }
+  }
+
+  // Something else is holding the CLI lock. The call did no work and returned
+  // no state, so nothing is concluded from it; the next poll asks again.
+  function cliLocked(out, err) {
+    return Model.isWindscribeCliLocked(out) || Model.isWindscribeCliLocked(err)
+  }
+
+  function finishStatus(exitCode, out, err) {
+    var parsed = Model.parseWindscribeStatus(out)
+
+    if (exitCode !== 0 || !parsed.loaded) {
+      if (root.cliLocked(out, err)) return
+
+      // Nothing recognizable came back: the app is not running, or this is a
+      // CLI whose output this parser does not know. Either way the last reading
+      // is not evidence about now, so drop it rather than keep presenting it.
+      root._statusFailed = true
+      root.status = Model.parseWindscribeStatus("")
+      root.lastError = Model.elide(err || out || "Could not read Windscribe status", 140)
+      return
+    }
+
+    root._statusFailed = false
+    root.applyStatus(out)
+  }
+
+  // "Loaded" means asked and answered. A list this parser cannot read is a
+  // reason to say so once, not to re-fetch two hundred lines on every poll for
+  // as long as the shell runs.
+  function finishLocations(exitCode, out) {
+    if (exitCode !== 0 || root.cliLocked(out, "")) return
+
+    root.locations = Model.parseWindscribeLocations(out)
+    root.locationsLoaded = true
+    if (root.locations.length === 0) {
+      root.lastError = "Could not read the location list. Check: windscribe-cli locations"
+    }
+  }
+
+  function finishAction(exitCode, out, err) {
+    // A non-zero exit here means the request was refused outright — a location
+    // name the daemon does not know, or a client that cannot reach the app. The
+    // other kind of failure exits 0 and surfaces in the status line seconds
+    // later, which is what the settle timer is watching for.
+    if (exitCode !== 0 || root.cliLocked(out, err)) {
+      root._desired = -1
+      root.lastError = Model.elide(err || out || "Windscribe command failed", 140)
+    }
+    root.actionStatus = ""
+    settleTimer.ticks = 0
+    settleTimer.restart()
+    root.refresh()
+  }
+
+  function finishToggle(exitCode, out, err) {
+    if (exitCode !== 0 || root.cliLocked(out, err)) {
+      root.lastError = Model.elide(err || out || "Windscribe refused that setting", 140)
+      root.clearPending(root._toggleKey)
+    }
+    root._toggleKey = ""
+    root.enqueue("status", ["status"])
+  }
+}

--- a/WindscribeBackend.qml
+++ b/WindscribeBackend.qml
@@ -40,8 +40,13 @@ Item {
 
   property bool _present: false
   property bool _probed: false
-  // The app is not answering — installed, but nothing behind the socket.
+  // The app is not answering — installed, but nothing behind the socket. What
+  // the tool last said is kept rather than blanked, so this means "the reading
+  // below is old", not "there is nothing to report".
   property bool _statusFailed: false
+  // A reading has landed at least once, so `_statusFailed` describes something
+  // going stale rather than a tool that has never answered.
+  property bool _statusSeen: false
 
   // The binary alone says nothing: `windscribe-cli` is a client, and a client
   // nobody is logged into has no locations to offer and cannot connect. The
@@ -50,15 +55,16 @@ Item {
 
   readonly property string setupHint: {
     if (!_present) return ""
-    if (_statusFailed) return "Windscribe is installed but its app is not answering. Start Windscribe, then reopen this panel."
+    if (_statusFailed && !_statusSeen) return "Windscribe is installed but its app is not answering. Start Windscribe, then reopen this panel."
     if (status.loaded && !status.loggedIn) return "Windscribe is installed but not logged in. Log in with: windscribe-cli login"
     return ""
   }
 
   // Windscribe's firewall is a kill switch: while it is on and the tunnel is
   // down, nothing leaves the machine at all — including the traffic another
-  // backend's connect needs.
-  readonly property bool lockdownMode: detected && status.firewallOn && !connected
+  // backend's connect needs. An unreadable firewall line counts as "might be" —
+  // see windscribeBlocksWhileDown.
+  readonly property bool lockdownMode: detected && !connected && Model.windscribeBlocksWhileDown(status)
   readonly property string lockdownHint: "windscribe-cli firewall off"
 
   // The one setting the CLI can change. Its value is always what the app last
@@ -105,64 +111,26 @@ Item {
   // these queues, each disciplined and each unaware of the other. Ordering
   // within one instance is not enough — see the retry in onExited.
   property var _queue: []
-  property string _running: ""
+  // The job on the wire, or null. Its `kind` is the only record of what is
+  // running — two fields saying the same thing is two fields that can disagree.
   property var _current: null
+  readonly property string _running: _current ? _current.kind : ""
 
-  readonly property bool _actionPending: {
-    if (_running === "connect" || _running === "disconnect") return true
-    for (var i = 0; i < _queue.length; i++) {
-      if (_queue[i].kind === "connect" || _queue[i].kind === "disconnect") return true
-    }
-    return false
-  }
+  readonly property bool _actionPending: Model.windscribePending(_queue, _running, ["connect", "disconnect"])
+  readonly property bool _togglePending: Model.windscribePending(_queue, _running, ["toggle"])
 
-  readonly property bool _togglePending: {
-    if (_running === "toggle") return true
-    for (var i = 0; i < _queue.length; i++) {
-      if (_queue[i].kind === "toggle") return true
-    }
-    return false
-  }
-
-  // Reads are idempotent, so a second one waiting behind the first is a stale
-  // answer nobody asked for: the poll fires faster than the CLI replies, and a
-  // backlog of them would keep the panel a cycle behind for as long as the
-  // shell ran. A click goes to the front, because waiting out a two-hundred
-  // line location fetch is not what "connect" should feel like.
   function enqueue(kind, args) {
-    if (kind === "status" || kind === "locations") {
-      if (_running === kind) return
-      for (var i = 0; i < _queue.length; i++) {
-        if (_queue[i].kind === kind) return
-      }
-    }
-
-    var queue = _queue.slice()
-    var job = { kind: kind, args: args, attempts: 0 }
-    if (kind === "status" || kind === "locations") queue.push(job)
-    else queue.unshift(job)
+    var queue = Model.windscribeEnqueue(_queue, _running, kind, args)
+    if (queue === _queue) return
     _queue = queue
     pump()
   }
 
-  // Put a job that lost the lock back at the head of its own queue. Bounded,
-  // because a lock held by something that is never going to let go is not
-  // something to keep knocking on: past the last attempt the job runs its
-  // finisher, which treats the refusal as inconclusive rather than as news.
   function retry(job) {
-    if (job.attempts >= 4) return false
+    if (!Model.windscribeCanRetry(job)) return false
 
-    job.attempts += 1
-    var queue = _queue.slice()
-    queue.unshift(job)
-    _queue = queue
-
-    // The jitter is not decoration. Two instances that started together lose
-    // together — that is what a shared lock and a shared poll interval do — and
-    // backing off by the same amount would have them collide again on every
-    // round. Something has to break the tie, and the attempt count cannot: it
-    // is identical on both sides.
-    retryTimer.interval = 120 * job.attempts + Math.floor(Math.random() * 280)
+    _queue = Model.windscribeRequeue(_queue, job)
+    retryTimer.interval = Model.windscribeRetryDelay(job.attempts + 1, Math.random())
     retryTimer.restart()
     return true
   }
@@ -174,22 +142,18 @@ Item {
     onTriggered: root.pump()
   }
 
+  // Never starts a job while one is on the wire, and never arranges to be
+  // called back for one either: the running job's onExited pumps, so a caller
+  // who arrives mid-job can simply leave. An earlier version re-armed a
+  // zero-interval timer here, which turned a hung CLI into a shell that spun
+  // through the event loop for as long as the hang lasted.
   function pump() {
-    if (_running !== "" || _queue.length === 0) return
-    // The bookkeeping is cleared in onExited, which can run a moment before the
-    // process itself reports finished. Come back rather than drop the job: the
-    // queue is only pumped on an enqueue otherwise, and the next one may be a
-    // poll interval away.
-    if (cliProcess.running) {
-      pumpTimer.restart()
-      return
-    }
+    if (_current !== null || cliProcess.running || _queue.length === 0) return
 
     var queue = _queue.slice()
     var job = queue.shift()
     _queue = queue
     _current = job
-    _running = job.kind
     cliProcess.command = ["windscribe-cli"].concat(job.args)
     cliProcess.running = true
     stallTimer.restart()
@@ -197,29 +161,34 @@ Item {
 
   // Starting the next job from inside onExited would re-enter the process that
   // is still finishing, the same reason the other backends hop through a timer
-  // to chain their two-step connects.
+  // to chain their two-step connects. The delay is small but not zero, so that
+  // arriving a moment before the process reports finished costs one more tick
+  // rather than a spin.
   Timer {
     id: pumpTimer
-    interval: 0
+    interval: 50
     repeat: false
     onTriggered: root.pump()
   }
 
   // One job at a time only works while every job ends. A process that never
-  // reports back would leave `_running` set forever, and since a read already
-  // in flight is never queued twice, the backend would stop asking about the
-  // tunnel for as long as the shell ran and quietly present its last reading as
-  // current. Nothing this CLI does takes half a minute, so past that the job is
-  // written off. `pump` still refuses to start while the process object says it
-  // is running, so writing it off cannot put two of them on the lock.
+  // reports back would hold `_current` forever, and since a read already in
+  // flight is never queued twice, the backend would stop asking about the
+  // tunnel for as long as the shell ran while still presenting its last reading
+  // as current.
+  //
+  // So the process is killed rather than forgotten. Forgetting it would leave
+  // it holding the machine-wide lock — blocking every other monitor's copy of
+  // this widget as well as this one — while `pump` refused to start anything
+  // behind it. Killing it makes `onExited` fire, which does the bookkeeping by
+  // the usual path. Nothing this CLI does takes half a minute.
   Timer {
     id: stallTimer
     interval: 30000
     repeat: false
     onTriggered: {
-      root._running = ""
       root._current = null
-      root.pump()
+      cliProcess.running = false
     }
   }
 
@@ -232,6 +201,11 @@ Item {
   function detect(force) {
     if (presenceProbe.running) return
     if (_probed && force !== true) return
+    // `force` is the user asking again, which is the one moment the location
+    // list could have gone stale in a way they can see: upgrading the account
+    // turns "Pro only" rows into connectable ones, and nothing else would ever
+    // re-read them.
+    if (force === true) locationsLoaded = false
     presenceProbe.running = true
   }
 
@@ -269,6 +243,17 @@ Item {
     pendingTimer.restart()
   }
 
+  // Connecting and disconnecting are allowed to move the firewall on their own:
+  // with the app's firewall mode on `Auto` it goes on before a connect and off
+  // after a disconnect. A switch still waiting to be agreed with would never be,
+  // and the panel would end up accusing the tool of ignoring a setting it had
+  // simply been told to change by something else.
+  function forgetPendingToggles() {
+    if (Object.keys(_pendingToggles).length === 0) return
+    _pendingToggles = ({})
+    pendingTimer.stop()
+  }
+
   function clearPending(key) {
     var pending = {}
     for (var name in _pendingToggles) {
@@ -287,6 +272,7 @@ Item {
     _desired = 1
     lastError = ""
     actionStatus = "Connecting to " + target.label + "…"
+    forgetPendingToggles()
     enqueue("connect", ["connect", "-n"].concat(target.args || []))
   }
 
@@ -295,6 +281,7 @@ Item {
     _desired = 0
     lastError = ""
     actionStatus = "Disconnecting…"
+    forgetPendingToggles()
     enqueue("disconnect", ["disconnect", "-n"])
   }
 
@@ -408,7 +395,6 @@ Item {
       var err = String(cliStderr.text || "")
 
       stallTimer.stop()
-      root._running = ""
       root._current = null
 
       // Somebody else had the lock. Nothing was read and nothing was done, so
@@ -417,7 +403,7 @@ Item {
       if (job && root.cliLocked(out, err) && root.retry(job)) return
 
       if (kind === "status") root.finishStatus(exitCode, out, err)
-      else if (kind === "locations") root.finishLocations(exitCode, out)
+      else if (kind === "locations") root.finishLocations(exitCode, out, err)
       else if (kind === "toggle") root.finishToggle(exitCode, out, err)
       else if (kind !== "") root.finishAction(exitCode, out, err)
 
@@ -438,23 +424,39 @@ Item {
       if (root.cliLocked(out, err)) return
 
       // Nothing recognizable came back: the app is not running, or this is a
-      // CLI whose output this parser does not know. Either way the last reading
-      // is not evidence about now, so drop it rather than keep presenting it.
+      // CLI whose output this parser does not know. The last reading is kept
+      // and flagged stale rather than replaced with a blank one, for two
+      // reasons that both bite hardest at exactly this moment.
+      //
+      // `detected` follows the login state, so blanking would take the chip
+      // away while a tunnel is up — and with it the only way to bring that
+      // tunnel down, since every verb here refuses to run undetected. It is the
+      // hazard NetworkManagerBackend keeps its own stale list to avoid.
+      //
+      // And a blank status reports the firewall as off. Losing contact with the
+      // app is precisely when the widget must not start claiming that nothing
+      // is being blocked.
       root._statusFailed = true
-      root.status = Model.parseWindscribeStatus("")
-      root.lastError = Model.elide(err || out || "Could not read Windscribe status", 140)
+      root.lastError = root._statusSeen
+        ? "Windscribe is not answering — showing the last known state."
+        : Model.elide(err || out || "Could not read Windscribe status", 140)
       return
     }
 
     root._statusFailed = false
+    root._statusSeen = true
     root.applyStatus(out)
   }
 
   // "Loaded" means asked and answered. A list this parser cannot read is a
   // reason to say so once, not to re-fetch two hundred lines on every poll for
   // as long as the shell runs.
-  function finishLocations(exitCode, out) {
-    if (exitCode !== 0 || root.cliLocked(out, "")) return
+  function finishLocations(exitCode, out, err) {
+    // A refusal read as an empty list would latch `locationsLoaded` and the
+    // error below for the life of the shell, since nothing re-fetches after a
+    // successful-looking answer. Today's CLI prints the refusal on both
+    // streams; this does not depend on that staying true.
+    if (exitCode !== 0 || root.cliLocked(out, err)) return
 
     root.locations = Model.parseWindscribeLocations(out)
     root.locationsLoaded = true

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "VPN",
-    "description": "Detects installed VPN tools (Proton VPN, Mullvad, and NetworkManager's OpenVPN and WireGuard profiles) and switches between them from one bar icon.",
+    "description": "Detects installed VPN tools (Proton VPN, Mullvad, Windscribe, and NetworkManager's OpenVPN and WireGuard profiles) and switches between them from one bar icon.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",
@@ -38,7 +38,7 @@
         "key": "preferredBackend",
         "type": "enum",
         "label": "VPN tool shown first",
-        "options": ["Auto", "Proton VPN", "Mullvad", "NetworkManager"],
+        "options": ["Auto", "Proton VPN", "Mullvad", "Windscribe", "NetworkManager"],
         "defaultValue": "Auto",
         "description": "Auto picks whichever detected tool is connected, otherwise the first one found."
       },
@@ -46,14 +46,15 @@
         "key": "favoriteCountries",
         "type": "string",
         "label": "Favorite countries (comma separated)",
-        "defaultValue": "CH,NL,US"
+        "defaultValue": "CH,NL,US",
+        "description": "Two-letter codes for Proton VPN and Mullvad. Windscribe names its regions instead, so it matches full names (\"Switzerland\") and leading words (\"US\" picks up US East, US Central and US West)."
       },
       {
         "key": "hiddenBackends",
         "type": "string",
         "label": "Hidden VPN tools (comma separated)",
         "defaultValue": "",
-        "description": "Tools the widget ignores entirely: proton, mullvad, networkmanager. Also editable from the gear inside the panel."
+        "description": "Tools the widget ignores entirely: proton, mullvad, windscribe, networkmanager. Also editable from the gear inside the panel."
       }
     ]
   }

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,5 +1,5 @@
 // Tests for Model.js — the pure half of the widget, where every assumption
-// about how three CLIs format their output is written down.
+// about how four CLIs format their output is written down.
 //
 //   node tests/run.js
 //
@@ -657,6 +657,104 @@ test("windscribeToggleArgs speak the CLI's firewall vocabulary", () => {
   eq(Model.windscribeToggleArgs("firewall", true), ["firewall", "on"])
   eq(Model.windscribeToggleArgs("firewall", false), ["firewall", "off"])
   eq(Model.windscribeToggleArgs("nonsense", true), [])
+})
+
+// A kill switch nobody can read is not a kill switch that is off. The panel's
+// summary reports what the tool said; this weighs what it might be doing, and
+// it is what decides whether switching tools comes with a warning.
+test("windscribeBlocksWhileDown counts an unreadable firewall as maybe blocking", () => {
+  const on = Model.parseWindscribeStatus("Login state: Logged in\nFirewall state: On\nConnect state: Disconnected")
+  const off = Model.parseWindscribeStatus("Login state: Logged in\nFirewall state: Off\nConnect state: Disconnected")
+  const odd = Model.parseWindscribeStatus("Login state: Logged in\nFirewall state: Whatever\nConnect state: Disconnected")
+
+  eq(Model.windscribeBlocksWhileDown(on), true)
+  eq(Model.windscribeBlocksWhileDown(off), false)
+  eq(Model.windscribeBlocksWhileDown(odd), true)
+  // Never asked is not the same as asked and unreadable: with no reading at all
+  // the backend is not detected, and warning about it would be noise.
+  eq(Model.windscribeBlocksWhileDown(Model.parseWindscribeStatus("")), false)
+  eq(Model.windscribeBlocksWhileDown(null), false)
+})
+
+// -------------------------------------------------- Windscribe call queue
+
+const kinds = queue => queue.map(job => job.kind)
+
+test("windscribeEnqueue puts reads at the back and actions at the front", () => {
+  let queue = []
+  queue = Model.windscribeEnqueue(queue, "", "status", ["status"])
+  queue = Model.windscribeEnqueue(queue, "", "locations", ["locations"])
+  eq(kinds(queue), ["status", "locations"])
+
+  queue = Model.windscribeEnqueue(queue, "", "connect", ["connect", "-n", "best"])
+  eq(kinds(queue), ["connect", "status", "locations"])
+  eq(queue[0].args, ["connect", "-n", "best"])
+  eq(queue[0].attempts, 0)
+})
+
+// The poll fires faster than the CLI answers, so without this the queue grows a
+// backlog of stale reads and the panel runs a cycle behind forever.
+test("windscribeEnqueue drops a read that is already queued or running", () => {
+  const queued = Model.windscribeEnqueue([], "", "status", ["status"])
+
+  eq(Model.windscribeEnqueue(queued, "", "status", ["status"]), queued)
+  eq(Model.windscribeEnqueue([], "status", "status", ["status"]), [])
+  eq(Model.windscribeEnqueue([], "locations", "status", ["status"]).length, 1)
+
+  // Actions are not reads: two clicks are two intentions, and the caller — not
+  // the queue — is what decides a second one is redundant.
+  const twice = Model.windscribeEnqueue(
+    Model.windscribeEnqueue([], "", "connect", ["a"]), "", "connect", ["b"])
+  eq(kinds(twice), ["connect", "connect"])
+})
+
+test("windscribeRequeue returns the job to the front, one attempt older", () => {
+  const job = { kind: "status", args: ["status"], attempts: 0 }
+  const queue = Model.windscribeRequeue([{ kind: "locations", args: [], attempts: 0 }], job)
+
+  eq(kinds(queue), ["status", "locations"])
+  eq(queue[0].attempts, 1)
+  // A fresh object: nothing holding the old job sees its count move.
+  eq(job.attempts, 0)
+})
+
+test("windscribeCanRetry stops knocking after four attempts", () => {
+  eq(Model.windscribeCanRetry({ kind: "status", args: [], attempts: 0 }), true)
+  eq(Model.windscribeCanRetry({ kind: "status", args: [], attempts: 3 }), true)
+  eq(Model.windscribeCanRetry({ kind: "status", args: [], attempts: 4 }), false)
+  eq(Model.windscribeCanRetry(null), false)
+})
+
+// Two widget instances lose the lock together and would back off together, so
+// the draw is what separates them — the attempt count is identical on both.
+test("windscribeRetryDelay grows with attempts and spreads with the draw", () => {
+  eq(Model.windscribeRetryDelay(1, 0), 120)
+  eq(Model.windscribeRetryDelay(2, 0), 240)
+  eq(Model.windscribeRetryDelay(1, 1), 400)
+  eq(Model.windscribeRetryDelay(1, 0.5), 260)
+  // A draw outside 0..1, or no draw at all, must not produce a negative or
+  // absurd interval — a Timer given one never fires again.
+  eq(Model.windscribeRetryDelay(1, -5), 120)
+  eq(Model.windscribeRetryDelay(1, 99), 400)
+  eq(Model.windscribeRetryDelay(1, undefined), 120)
+})
+
+test("windscribePending sees both the running job and the waiting ones", () => {
+  const queue = [{ kind: "toggle", args: [], attempts: 0 }]
+
+  eq(Model.windscribePending(queue, "status", ["toggle"]), true)
+  eq(Model.windscribePending(queue, "connect", ["connect", "disconnect"]), true)
+  eq(Model.windscribePending(queue, "status", ["connect", "disconnect"]), false)
+  eq(Model.windscribePending([], "", ["connect"]), false)
+})
+
+// The name is handed to `windscribe-cli connect` as an argument, where a
+// leading dash reads as an option rather than as a place.
+test("windscribeRegions drops a region name that would parse as a flag", () => {
+  const locations = Model.parseWindscribeLocations(
+    "--nope - Somewhere - Trap (10 Gbps)\nSwitzerland - Zurich - Alphorn (10 Gbps)")
+
+  eq(Model.windscribeRegions(locations).map(region => region.name), ["Switzerland"])
 })
 
 // ------------------------------------------------------------------ report

--- a/tests/run.js
+++ b/tests/run.js
@@ -418,6 +418,247 @@ test("mullvadToggleArgs speaks each setting's own vocabulary", () => {
   eq(Model.mullvadToggleArgs("nonsense", true), [])
 })
 
+// --------------------------------------------------------------- Windscribe
+
+const WINDSCRIBE_CONNECTED = [
+  "Internet connectivity: available",
+  "Login state: Logged in",
+  "Firewall state: On",
+  "Connect state: Connected: Zurich - Alphorn",
+  "Protocol: WireGuard:443",
+  "Data usage: 96.99 MB / 2.00 GB",
+  "Update available: 2.23.11"
+].join("\n")
+
+const WINDSCRIBE_DISCONNECTED = [
+  "Internet connectivity: available",
+  "Login state: Logged in",
+  "Firewall state: Off",
+  "Connect state: Disconnected",
+  "Data usage: 0 bytes / 2.00 GB"
+].join("\n")
+
+const WINDSCRIBE_LOCATIONS = [
+  "Best Location - Alphorn (10 Gbps)",
+  "US East - New York - Empire (10 Gbps)",
+  "US East - Boston - MIT (Pro) (10 Gbps)",
+  "US West - Seattle - Cobain (10 Gbps)",
+  "Switzerland - Zurich - Alphorn (10 Gbps)",
+  "Switzerland - Zurich - Altstadt (Pro) (10 Gbps)",
+  "Japan - Tokyo - Shinkansen (Pro) (10 Gbps)",
+  "Nowhere - Ghost Town - Closed (Pro) (Disabled)"
+].join("\n")
+
+test("parseWindscribeStatus reads the connected block", () => {
+  const status = Model.parseWindscribeStatus(WINDSCRIBE_CONNECTED)
+  eq(status.loaded, true)
+  eq(status.loggedIn, true)
+  eq(status.state, "connected")
+  eq(status.connected, true)
+  eq(status.city, "Zurich")
+  eq(status.nickname, "Alphorn")
+  eq(status.protocol, "WireGuard")
+  eq(status.port, "443")
+  eq(status.dataUsed, "96.99 MB")
+  eq(status.dataLimit, "2.00 GB")
+  eq(status.firewallKnown, true)
+  eq(status.firewallOn, true)
+  eq(status.firewallAlways, false)
+  eq(status.statusText, "Connected")
+})
+
+test("parseWindscribeStatus reads the disconnected block", () => {
+  const status = Model.parseWindscribeStatus(WINDSCRIBE_DISCONNECTED)
+  eq(status.state, "disconnected")
+  eq(status.connected, false)
+  eq(status.firewallKnown, true)
+  eq(status.firewallOn, false)
+  eq(status.protocol, "")
+  eq(Model.windscribeSummary(status), "Not connected")
+})
+
+test("parseWindscribeStatus treats an unreadable block as no answer", () => {
+  const status = Model.parseWindscribeStatus("")
+  eq(status.loaded, false)
+  eq(status.state, "")
+  eq(status.connected, false)
+  eq(status.firewallKnown, false)
+  eq(Model.windscribeSummary(status), "Checking…")
+  eq(Model.windscribeToggles(status), [])
+})
+
+// The one failure mode `connect -n` cannot report through its exit code.
+test("parseWindscribeStatus keeps a failed connect out of the connected state", () => {
+  const status = Model.parseWindscribeStatus(
+    "Login state: Logged in\nFirewall state: Off\nConnect state: Error: Location does not exist or is disabled")
+  eq(status.state, "error")
+  eq(status.connected, false)
+  eq(status.error, "Location does not exist or is disabled")
+  eq(Model.windscribeSummary(status), "Not connected")
+  eq(Model.windscribeDetails(status), [])
+})
+
+test("parseWindscribeStatus keeps the reason on a disconnect that has one", () => {
+  const limit = "Disconnected due to reaching WireGuard key limit.  Use \"windscribe-cli keylimit delete\" if you want to."
+  const status = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: " + limit)
+  eq(status.state, "disconnected")
+  eq(status.connected, false)
+  eq(status.error, limit)
+})
+
+test("parseWindscribeStatus reads connecting, disconnecting and interference", () => {
+  const connecting = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Connecting: Zurich - Alphorn")
+  eq(connecting.state, "connecting")
+  eq(connecting.connected, false)
+  eq(Model.windscribeSummary(connecting), "Connecting to Alphorn · Zurich…")
+
+  const bare = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Connecting")
+  eq(bare.state, "connecting")
+  eq(Model.windscribeSummary(bare), "Connecting…")
+
+  const down = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Disconnecting")
+  eq(down.state, "disconnecting")
+  eq(Model.windscribeSummary(down), "Disconnecting…")
+
+  const noisy = Model.parseWindscribeStatus(
+    "Login state: Logged in\nConnect state: Connected: Zurich - Alphorn [Network interference]")
+  eq(noisy.state, "connected")
+  eq(noisy.nickname, "Alphorn")
+  eq(noisy.interference, true)
+  eq(Model.windscribeSummary(noisy), "Alphorn · Zurich · network interference")
+})
+
+test("windscribeSummary says so when a logged-out client is all there is", () => {
+  const status = Model.parseWindscribeStatus("Login state: Logged out\nFirewall state: Off\nConnect state: Disconnected")
+  eq(status.loggedIn, false)
+  eq(status.statusText, "Not logged in")
+  eq(Model.windscribeSummary(status), "Not logged in")
+})
+
+// The firewall is a kill switch, so an unrecognized spelling is unknown rather
+// than off — a switch that is not drawn beats one that is confidently wrong.
+test("parseWindscribeStatus believes only the firewall spellings it knows", () => {
+  const always = Model.parseWindscribeStatus("Login state: Logged in\nFirewall state: Always On")
+  eq(always.firewallOn, true)
+  eq(always.firewallAlways, true)
+  eq(Model.windscribeToggles(always)[0].detail, "Always on — change it in the Windscribe app")
+
+  const odd = Model.parseWindscribeStatus("Login state: Logged in\nFirewall state: Whatever")
+  eq(odd.firewallKnown, false)
+  eq(odd.firewallOn, false)
+  eq(Model.windscribeToggles(odd), [])
+})
+
+test("windscribeDetails reports the server, the plan and the protocol", () => {
+  eq(Model.windscribeDetails(Model.parseWindscribeStatus(WINDSCRIBE_CONNECTED)), [
+    { label: "Server", value: "Alphorn" },
+    { label: "Location", value: "Zurich" },
+    { label: "Protocol", value: "WireGuard · 443" },
+    { label: "Data used", value: "96.99 MB of 2.00 GB" }
+  ])
+  eq(Model.windscribeDetails(Model.parseWindscribeStatus(WINDSCRIBE_DISCONNECTED)), [])
+})
+
+test("parseWindscribeLocations strips the markers and keeps the names", () => {
+  const locations = Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS)
+  eq(locations.length, 8)
+  eq(locations[0], { region: "Best Location", city: "", nickname: "Alphorn", pro: false, disabled: false })
+  eq(locations[2], { region: "US East", city: "Boston", nickname: "MIT", pro: true, disabled: false })
+  eq(locations[7], { region: "Nowhere", city: "Ghost Town", nickname: "Closed", pro: true, disabled: true })
+})
+
+test("parseWindscribeLocations ignores the empty and static-IP preamble lines", () => {
+  eq(Model.parseWindscribeLocations("(Device name: laptop)\n\nNo locations.\n"), [])
+  eq(Model.parseWindscribeLocations(null), [])
+})
+
+test("windscribeRegions groups the list and drops what cannot be connected to", () => {
+  const regions = Model.windscribeRegions(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS))
+  eq(regions.map(region => region.name), ["US East", "US West", "Switzerland", "Japan"])
+  eq(regions[0].cities, ["New York", "Boston"])
+  eq(regions[0].total, 2)
+  eq(regions[0].free, 1)
+  eq(regions[3].free, 0)
+  eq(Model.windscribeBestNickname(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS)), "Alphorn")
+})
+
+test("windscribeRegionTargets connect by region name and warn about Pro", () => {
+  const regions = Model.windscribeRegions(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS))
+  const targets = Model.windscribeRegionTargets(regions, [], "")
+
+  eq(targets[0], {
+    key: "region:us east",
+    label: "US East",
+    detail: "2 cities",
+    glyph: Model.GLYPH_VPN,
+    args: ["US East"]
+  })
+  eq(targets[3].detail, "1 city · Pro only")
+})
+
+test("windscribeRegionTargets filter over region, city and nickname", () => {
+  const regions = Model.windscribeRegions(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS))
+  const names = filter => Model.windscribeRegionTargets(regions, [], filter).map(target => target.label)
+
+  eq(names("zurich"), ["Switzerland"])
+  eq(names("cobain"), ["US West"])
+  eq(names("us "), ["US East", "US West"])
+  eq(names("nowhere"), [])
+})
+
+// Windscribe prints no country codes, so the shared favorites setting has to
+// match on the name — and on its leading word, or "US" would match nothing.
+test("windscribe favorites match region names and leading words", () => {
+  const regions = Model.windscribeRegions(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS))
+  const order = favorites => Model.windscribeRegionTargets(regions, favorites, "").map(target => target.label)
+
+  eq(order(Model.favoriteCodes("Switzerland")), ["Switzerland", "US East", "US West", "Japan"])
+  eq(order(Model.favoriteCodes("us")), ["US East", "US West", "Switzerland", "Japan"])
+  eq(order(Model.favoriteCodes("CH,NL")), ["US East", "US West", "Switzerland", "Japan"])
+  eq(Model.isWindscribeFavorite("US East", []), false)
+})
+
+test("windscribeQuickTargets name the server best resolves to when it is known", () => {
+  eq(Model.windscribeQuickTargets("Alphorn")[0].detail, "Currently Alphorn")
+  eq(Model.windscribeQuickTargets("")[0].detail, "Let Windscribe pick")
+  eq(Model.windscribeQuickTargets("")[0].args, ["best"])
+})
+
+// Status names a city and a nickname; the list is what says which region they
+// are in, so the tick has to be looked back up rather than read off.
+test("windscribeCurrentKey finds the region behind the connected server", () => {
+  const regions = Model.windscribeRegions(Model.parseWindscribeLocations(WINDSCRIBE_LOCATIONS))
+
+  eq(Model.windscribeCurrentKey(Model.parseWindscribeStatus(WINDSCRIBE_CONNECTED), regions), "region:switzerland")
+  eq(Model.windscribeCurrentKey(Model.parseWindscribeStatus(WINDSCRIBE_DISCONNECTED), regions), "")
+
+  const connecting = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Connecting: Boston - MIT")
+  eq(Model.windscribeCurrentKey(connecting, regions), "region:us east")
+
+  const nicknameOnly = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Connected: Cobain")
+  eq(Model.windscribeCurrentKey(nicknameOnly, regions), "region:us west")
+
+  const unknown = Model.parseWindscribeStatus("Login state: Logged in\nConnect state: Connected: Atlantis - Trident")
+  eq(Model.windscribeCurrentKey(unknown, regions), "")
+})
+
+// Two overlapping invocations lose both answers, so the backend serialises its
+// calls — but the user at a terminal is outside that queue, and what comes back
+// then is a refusal rather than a reading.
+test("isWindscribeCliLocked spots the refusal a second invocation gets", () => {
+  eq(Model.isWindscribeCliLocked("cli: \"Windscribe CLI is already running\""), true)
+  eq(Model.isWindscribeCliLocked("Windscribe CLI is already running"), true)
+  eq(Model.isWindscribeCliLocked(WINDSCRIBE_DISCONNECTED), false)
+  eq(Model.isWindscribeCliLocked(""), false)
+  eq(Model.isWindscribeCliLocked(null), false)
+})
+
+test("windscribeToggleArgs speak the CLI's firewall vocabulary", () => {
+  eq(Model.windscribeToggleArgs("firewall", true), ["firewall", "on"])
+  eq(Model.windscribeToggleArgs("firewall", false), ["firewall", "off"])
+  eq(Model.windscribeToggleArgs("nonsense", true), [])
+})
+
 // ------------------------------------------------------------------ report
 
 for (const failure of failures) {


### PR DESCRIPTION
Closes #10.

Windscribe via `windscribe-cli`, as one more backend behind the existing contract. One new file, one line in the controller.

## What it does

- **The list** is Windscribe's own regions — a country most of the time, a slice of one where a country has too many (`US East`, `US West`) — since `connect` takes a region name directly. Cities and server nicknames stay searchable, so both `zurich` and `alphorn` find Switzerland. **Best location** hands the choice back to Windscribe and names the server it currently resolves to.
- **Pro only** on regions holding nothing a free account can reach. The CLI's own refusal — `Location does not exist or is disabled` — does not say which of the two it meant, so the row says it instead.
- **The firewall** is the one switch in the tool drawer, and doubles as `lockdownMode`: firewall on with the tunnel down blocks everything, including the traffic another backend's connect needs.
- **The data allowance** on the detail rows. A free plan is metered and the CLI prints the number nowhere else.
- **The chip appears only once the app is running and logged in.** `windscribe-cli` is a client, so the binary being present says nothing. `setupHint` says which half is missing.

## Two things the CLI forced

**`connect` is non-blocking.** A blocking call would hold the CLI lock — and with it every status read — for the whole handshake, which is exactly the stretch the panel has something to say. The cost is that the exit code stops meaning anything: a free account reaching for a Pro location is accepted, exits 0, and fails seconds later with nothing but `Connect state: Error: …` to show for it. The optimistic state is dropped the moment a status read reports that error, rather than waiting out the settle timer and vouching for a tunnel that never came up.

**Two `windscribe-cli` invocations may not overlap.** The second exits with `Windscribe CLI is already running` and does no work, so every call goes through one queue and one process.

That turned out to be only half the problem, and the half that is easy to mistake for all of it. The lock is per machine, and each bar instantiates the widget separately — so a multi-monitor desktop runs several of these queues, each perfectly disciplined and each blind to the others. They poll on the same interval, collide on the same tick, and both lose. I hit this twice as an intermittent "the chip is missing" before tracing it. A refusal is therefore not a result: the job goes back to the head of its own queue and is retried with a jittered backoff (jittered because two instances that lost together would otherwise back off by the same amount and collide again every round). Only an unreadable status that is *not* a refusal is read as the app being gone.

## Also

The warning shown before one tool's kill switch is torn down for another now names that tool's own command, through a new optional `lockdownHint`. It was written in Mullvad's vocabulary, which was the wrong advice on any other chip.

## Testing

Built and verified against `windscribe-cli` 2.21.7 on a free account, on a three-monitor desktop.

- `node tests/run.js` — 54 passing, 24 of them new, covering the status block in each state, the sticky error `connect -n` leaves behind, the disconnect-with-a-reason, the location list and its markers, region grouping, filtering, favourites, and the current-key lookup.
- `qmllint` clean on every QML file. (`Panel.qml` exits 255 both with and without this change — the self-import quirk ARCHITECTURE already documents.)
- `omarchy plugin validate .` clean.
- Live: detect, connect by region, disconnect, cross-backend exclusivity in both directions, firewall on/off, public-IP refresh. Five cold shell starts detect the backend consistently; before the retry fix it missed roughly one in three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)