### PR TITLE
fix: Proton reads the status on a cadence and stops asking a signed-out CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,13 +150,43 @@ line rather than on line position, and handles both the modern combined form
 (`Server: CH#1129 in Zurich, Switzerland`) and older separate `Country`/`City`
 keys.
 
+**Proton spawns are expensive, and a signed-out CLI refuses forever.** Every
+non-hidden backend is polled on the interval whether or not the panel is open,
+and `protonvpn` is a Python entry point: roughly 0.75 CPU-seconds per invocation
+against a Go binary's few milliseconds. So Proton asks for one thing per poll,
+not three. `_configLoaded` and `countriesLoaded` both mean *asked and answered* —
+latched on the answer, not on the answer being usable — and `detect(force)` is
+what clears them, which is the user opening the panel or pressing `r`.
+
+The status read that remains runs at the rate the answer can change, not at the
+controller's. Connected reads every tick: a tunnel that drops behind a closed
+panel leaves the chip claiming protection nobody has, and overstating protection
+is the one wrong answer worth a Python start to avoid. Disconnected reads every
+fourth — understating it is harmless by comparison, and the only thing that makes
+it connected is somebody acting, either through the widget (`refreshNow()`, which
+is what `settleTimer` and a finished action use, ignores the cadence) or at a
+terminal, which the next slow tick catches inside a minute. Signed out does not
+read at all. Idle goes from twelve spawns a minute to one, or to none, and a
+two-monitor desktop instantiates all of this twice.
+
+Signed out is the case that made this matter: `protonvpn status` exits 0 and
+prints `Status: Disconnected`, so `detected` stays true and the poll runs
+happily, while `config list` and `countries list` each exit 2 with
+`Authentication required …`. Read as a plain failure that is three Python starts
+every 15 seconds for the life of the shell. `protonAuthRequired` tells that
+refusal apart from a tool that is unwell, `signedOut` latches it, and the panel
+says `protonvpn signin` instead of `Loading countries…` forever.
+
 **Settings are read, never owned.** `toggles` always reports what the tool
 itself last said, and the widget stores no copy — nothing in `manifest.json`
 asserts a desired value at startup. Turning lockdown on from the Mullvad CLI
 shows up in the panel on the next poll, and a widget restart never quietly puts a
-setting back. The cost is one extra read per refresh (`mullvad` answers three
-subcommands in one shell; Proton answers with `protonvpn config list`), which is
-a local call in both cases.
+setting back. The cost is one extra read (`mullvad` answers three subcommands in
+one shell; Proton answers with `protonvpn config list`), which is a local call in
+both cases — but only Mullvad pays it on every refresh. Proton reads its settings
+once and then when the user asks, because `protonvpn` is Python and a spawn there
+costs the better part of a CPU-second; the panel is the only thing that draws
+them, and opening it forces a refresh anyway.
 
 The block is a drawer behind the hero, closed by default: settings are read once
 and then left alone, while the target list is why the panel gets opened. The

--- a/MullvadBackend.qml
+++ b/MullvadBackend.qml
@@ -80,6 +80,9 @@ Item {
 
   function detect(force) {
     if (detectProcess.running) return
+    // Also the only thing that re-reads a relay list the CLI refused, since the
+    // guard below latches on the answer and not on the answer being usable.
+    if (force === true) relaysLoaded = false
     if (_probed && force !== true) return
     detectProcess.running = true
   }
@@ -324,13 +327,20 @@ Item {
     running: false
     command: ["mullvad", "relay", "list"]
     stdout: StdioCollector { id: relaysStdout; waitForEnd: true }
+    stderr: StdioCollector { id: relaysStderr; waitForEnd: true }
     onExited: function(exitCode) {
-      if (exitCode !== 0) return
-      root.relays = Mullvad.parseMullvadRelays(String(relaysStdout.text || ""))
+      // A refusal is an answer too. Returning here without latching left a
+      // daemon that was down — or a CLI that wanted an account — re-asked for
+      // the largest thing this tool prints on every poll, forever.
+      var unreadable = "Could not read the relay list. Check: mullvad relay list"
       root.relaysLoaded = true
-      if (root.relays.length === 0) {
-        root.lastError = "Could not read the relay list. Check: mullvad relay list"
+      if (exitCode !== 0) {
+        root.lastError = root.describeFailure(
+          String(relaysStderr.text || "") + "\n" + String(relaysStdout.text || ""), unreadable)
+        return
       }
+      root.relays = Mullvad.parseMullvadRelays(String(relaysStdout.text || ""))
+      if (root.relays.length === 0) root.lastError = unreadable
     }
   }
 

--- a/ProtonBackend.qml
+++ b/ProtonBackend.qml
@@ -26,6 +26,11 @@ Item {
   property var countries: []
   property bool countriesLoaded: false
   property var config: Proton.parseProtonConfig("")
+  // Same meaning as countriesLoaded: asked and answered, not answered well.
+  property bool _configLoaded: false
+  // Set the first time a subcommand is refused for want of an account, and the
+  // reason this backend stops asking. See noteAuth().
+  property bool signedOut: false
   property string actionStatus: ""
   property string lastError: ""
 
@@ -48,7 +53,9 @@ Item {
   readonly property string summary: Proton.protonSummary(status)
   readonly property var details: Proton.protonDetails(status)
   readonly property var favorites: Shared.favoriteCodes(setting("favoriteCountries", "CH,NL,US"))
-  readonly property string emptyText: countriesLoaded ? "No countries match." : "Loading countries…"
+  readonly property string emptyText: signedOut
+    ? Proton.PROTON_SIGNIN_HINT
+    : (countriesLoaded ? "No countries match." : "Loading countries…")
   // Server names carry their country: "NL#42" is the Netherlands row.
   readonly property string currentKey: {
     if (!connected) return ""
@@ -70,15 +77,82 @@ Item {
 
   function detect(force) {
     if (detectProcess.running) return
+    // `force` is the user asking again — opening the panel, pressing r — which
+    // is the one moment the answers below could have changed in a way they can
+    // see: they signed in at a terminal, or changed a setting from the CLI.
+    // Nothing else re-asks, because every one of these costs a Python start.
+    if (force === true) {
+      root._statusDue = true
+      root.signedOut = false
+      root.countriesLoaded = false
+      root._configLoaded = false
+    }
     if (_probed && force !== true) return
     detectProcess.running = true
   }
 
+  // Ticks of the controller's interval between status reads.
+  //
+  // Connected is every one. A tunnel that drops while the panel is closed leaves
+  // the chip claiming protection nobody has, and overstating protection is the
+  // one wrong answer here worth a Python start to avoid.
+  //
+  // Disconnected is every fourth. Understating it is harmless by comparison, and
+  // the only thing that turns disconnected into connected is somebody acting:
+  // through this widget, which re-reads on its own through settleTimer, or at a
+  // terminal, which the next slow tick catches within a minute.
+  //
+  // Signed out is never. The CLI cannot connect until somebody signs in, and
+  // that is a forced refresh — opening the panel — away.
+  readonly property int _statusEvery: signedOut ? 0 : (connected ? 1 : 4)
+  property int _sinceStatus: 0
+  // Ask on the next refresh whatever the cadence says. True at startup because
+  // the first thing a probe wants is an answer.
+  property bool _statusDue: true
+
+  // Every non-hidden backend is polled on the interval whether or not the panel
+  // is open, and `protonvpn` is Python: each invocation costs the best part of a
+  // CPU-second before it does any work. So the poll asks for the status alone
+  // once the other two have been answered, and asks for that on the cadence
+  // above rather than on every tick. Both of the others need an account, so
+  // signed out they are not asked at all.
   function refresh() {
-    if (!detected || statusProcess.running) return
-    statusProcess.running = true
-    if (!configProcess.running) configProcess.running = true
+    if (!detected) return
+
+    _sinceStatus += 1
+    if (_statusEvery > 0 && _sinceStatus >= _statusEvery) _statusDue = true
+
+    if (_statusDue && !statusProcess.running) {
+      _statusDue = false
+      _sinceStatus = 0
+      statusProcess.running = true
+    }
+
+    if (signedOut) return
+    if (!_configLoaded && !configProcess.running) configProcess.running = true
     if (!countriesLoaded && !countriesProcess.running) countriesProcess.running = true
+  }
+
+  // For the paths that have just changed something and need to see it land. The
+  // cadence is for the idle case; a settling action is not one.
+  function refreshNow() {
+    _statusDue = true
+    refresh()
+  }
+
+  // Latches the signed-out state from a refusal, and answers "was that a
+  // refusal" so callers can skip their success path. The CLI keeps refusing for
+  // as long as nobody signs in, and `protonvpn status` exits 0 throughout, so
+  // nothing else in the poll would ever notice.
+  function noteAuth(exitCode, out, err) {
+    if (exitCode === 0) {
+      root.signedOut = false
+      return false
+    }
+    if (!Proton.protonAuthRequired(String(err || "") + "\n" + String(out || ""))) return false
+    root.signedOut = true
+    root.lastError = Proton.PROTON_SIGNIN_HINT
+    return true
   }
 
   function setToggle(key, value) {
@@ -185,7 +259,7 @@ Item {
     running: false
     onTriggered: {
       settleTimer.ticks += 1
-      root.refresh()
+      root.refreshNow()
       if (settleTimer.ticks >= 4) {
         settleTimer.ticks = 0
         settleTimer.running = false
@@ -214,7 +288,9 @@ Item {
     onExited: function(exitCode) {
       if (exitCode === 0) {
         root.applyStatus(String(statusStdout.text || ""))
-        root.lastError = ""
+        // Status succeeds while signed out, so clearing unconditionally would
+        // wipe the one line telling the user why the panel is empty.
+        root.lastError = root.signedOut ? Proton.PROTON_SIGNIN_HINT : ""
       } else {
         root.lastError = Shared.elide(String(statusStderr.text || statusStdout.text || "") || "Could not read Proton VPN status", 140)
       }
@@ -228,16 +304,21 @@ Item {
     stdout: StdioCollector { id: connectStdout; waitForEnd: true }
     stderr: StdioCollector { id: connectStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      var connectOut = String(connectStdout.text || "")
+      var connectErr = String(connectStderr.text || "")
+      var refused = root.noteAuth(exitCode, connectOut, connectErr)
       if (exitCode !== 0) {
         root._desired = -1
-        root.lastError = Shared.elide(String(connectStderr.text || connectStdout.text || "") || "Proton VPN command failed", 140)
+        if (!refused) {
+          root.lastError = Shared.elide(connectErr || connectOut || "Proton VPN command failed", 140)
+        }
       } else {
         root.lastError = ""
       }
       root.actionStatus = ""
       settleTimer.ticks = 0
       settleTimer.restart()
-      root.refresh()
+      root.refreshNow()
     }
   }
 
@@ -246,9 +327,15 @@ Item {
     running: false
     command: ["protonvpn", "config", "list"]
     stdout: StdioCollector { id: configStdout; waitForEnd: true }
+    stderr: StdioCollector { id: configStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      var out = String(configStdout.text || "")
+      if (root.noteAuth(exitCode, out, String(configStderr.text || ""))) return
+      // Answered either way: a table this parser cannot read is a reason to show
+      // no switches, not to re-read it on every poll for the life of the shell.
+      root._configLoaded = true
       if (exitCode !== 0) return
-      root.applyConfig(String(configStdout.text || ""))
+      root.applyConfig(out)
     }
   }
 
@@ -277,13 +364,20 @@ Item {
     running: false
     command: ["protonvpn", "countries", "list"]
     stdout: StdioCollector { id: countriesStdout; waitForEnd: true }
+    stderr: StdioCollector { id: countriesStderr; waitForEnd: true }
     onExited: function(exitCode) {
-      if (exitCode !== 0) return
-      root.countries = Proton.parseProtonCountries(String(countriesStdout.text || ""))
+      var out = String(countriesStdout.text || "")
+      var err = String(countriesStderr.text || "")
+      if (root.noteAuth(exitCode, out, err)) return
+
+      var unreadable = "Could not read the country list. Check: protonvpn countries list"
       root.countriesLoaded = true
-      if (root.countries.length === 0) {
-        root.lastError = "Could not read the country list. Check: protonvpn countries list"
+      if (exitCode !== 0) {
+        root.lastError = Shared.elide(err || out || unreadable, 140)
+        return
       }
+      root.countries = Proton.parseProtonCountries(out)
+      if (root.countries.length === 0) root.lastError = unreadable
     }
   }
 }

--- a/model/Proton.js
+++ b/model/Proton.js
@@ -77,6 +77,22 @@ function parseProtonStatus(raw) {
   return result
 }
 
+// Anything that needs an account is refused the same way, whichever subcommand
+// asked. Signed out, `protonvpn countries list` exits 2 with:
+//
+//   Error: Authentication required to view feature status. Please sign in with 'protonvpn signin'
+//
+// `protonvpn status` still exits 0 and prints "Status: Disconnected", so the
+// poll notices nothing and keeps asking. Match on the phrases rather than the
+// whole sentence: the tail names whichever feature was asked for, and the
+// wording around it has moved between releases.
+function protonAuthRequired(text) {
+  return /authentication required|please sign\s?in|not (?:logged|signed)[- ]?in|sign in with/i.test(String(text || ""))
+}
+
+// Said in the CLI's own vocabulary, because the fix is a command the user runs.
+var PROTON_SIGNIN_HINT = "Signed out of Proton VPN. Sign in with: protonvpn signin"
+
 // `protonvpn countries list` prints a two-column table padded with spaces,
 // preceded by an optional "Server list is outdated, updating..." notice and a
 // dashed rule under the header.

--- a/tests/model/proton.test.js
+++ b/tests/model/proton.test.js
@@ -114,3 +114,19 @@ test("favoriteCodes normalises and de-duplicates", () => {
   eq(Shared.favoriteCodes(" ch , NL ,ch, "), ["CH", "NL"])
   eq(Shared.favoriteCodes(null), [])
 })
+
+// Signed out, every subcommand that needs an account is refused this way and
+// exits 2, while `protonvpn status` exits 0 the whole time — so this is the
+// only thing that tells the backend to stop asking.
+test("protonAuthRequired reads the CLI's refusals", () => {
+  eq(Proton.protonAuthRequired(
+    "Error: Authentication required to view feature status. Please sign in with 'protonvpn signin'"), true)
+  eq(Proton.protonAuthRequired("Error: Authentication required to list countries."), true)
+  eq(Proton.protonAuthRequired("You are not logged in"), true)
+  eq(Proton.protonAuthRequired(""), false)
+  eq(Proton.protonAuthRequired(null), false)
+  // A refusal is not the same as a tool that is unwell, and only the first of
+  // these should stop the poll asking again.
+  eq(Proton.protonAuthRequired("Error: could not reach the Proton VPN API"), false)
+  eq(Proton.protonAuthRequired("Status: Disconnected"), false)
+})


### PR DESCRIPTION
Fixes #19.

`protonvpn` is a Python entry point — roughly 0.75 CPU-seconds per invocation against a Go binary's few milliseconds — and every non-hidden backend is polled on the interval whether or not the panel is open. Proton was spawning three of them every tick, and a two-monitor desktop instantiates the widget twice.

`config list` ran unconditionally, and `countries list` latched `countriesLoaded` only on the success path, so a CLI that refused kept being asked. Signed out both exit 2 with `Authentication required …` while `protonvpn status` exits 0 and prints `Status: Disconnected`, so `detected` stayed true and nothing ever backed off: three Python starts every 15 seconds for the life of the shell.

## Spawns per minute, idle

| state | before | after |
|---|---|---|
| signed out | 12 | 0 |
| disconnected | 12 | 1 |
| connected | 8 | 4 |

## What changed

- **`model/Proton.js`** — `protonAuthRequired(text)` tells the auth refusal apart from a tool that is unwell; `PROTON_SIGNIN_HINT` names the fix in the CLI's own vocabulary.
- **`ProtonBackend.qml`**
  - `_configLoaded` and `countriesLoaded` both mean *asked and answered*, latched on the answer rather than on the answer being usable. `detect(force)` clears them along with `signedOut` — opening the panel, pressing `r`, or middle-clicking is the one moment they could have changed.
  - `noteAuth()` latches `signedOut` from any refused subcommand (config, countries, connect) and clears it on a clean exit. While it holds, neither account-dependent command is asked at all.
  - The status read runs on a cadence instead of on every tick: `_statusEvery` is 1 while connected, 4 while disconnected, and 0 while signed out. Connected keeps the full rate because a tunnel that drops behind a closed panel leaves the chip claiming protection nobody has — overstating protection is the wrong answer worth spending a spawn to avoid, and understating it is not. `refreshNow()` ignores the cadence and is what `settleTimer` and a finished connect/disconnect use, so an action still lands promptly.
  - A successful status read no longer wipes the sign-in hint on every poll, and `emptyText` says `protonvpn signin` instead of `Loading countries…` forever.
- **`MullvadBackend.qml`** — the relay list had the same early-return-before-latch shape, against its own comment saying loaded has to mean asked and answered. Cheap there, wrong anyway; failures now go through `describeFailure`, so a daemon that is down says so.
- **`ARCHITECTURE.md`** — new section on the spawn cost, the signed-out latch, and the cadence; the "one extra read per refresh" claim corrected, since it is Mullvad-only now.

## Known trade-off

Signed out, nothing is read until a forced refresh. Sign in at a terminal and connect without touching the widget and the chip stays stale until the panel is opened — which is also the moment it would be looked at. The alternative was polling a CLI that cannot connect, forever.

## Not done, on purpose

- `detected` stays true while signed out. Making it false — Windscribe's `present && loggedIn` shape — would take the polling to zero, but a session expiring while a tunnel is up would take the chip away and with it the only way to bring that tunnel down.
- No cadence for the other three backends. `mullvad`, `nmcli`, and `windscribe-cli` cost milliseconds; the complexity buys nothing, and Windscribe's queue already deduplicates reads.

## Testing

- `node tests/run.js` — 64 passed, 0 failed. Five new cases cover `protonAuthRequired` with the refusal from the issue pasted in verbatim.
- `qmllint` clean on `ProtonBackend.qml` and `MullvadBackend.qml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)