### PR TITLE
feat: OpenConnect profiles in the NetworkManager backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ surrounding workflow.
 | `ProtonBackend.qml` | Proton VPN, via the `protonvpn` CLI |
 | `MullvadBackend.qml` | Mullvad, via the `mullvad` CLI |
 | `WindscribeBackend.qml` | Windscribe, via `windscribe-cli` |
-| `NetworkManagerBackend.qml` | OpenVPN and WireGuard, via NetworkManager |
+| `NetworkManagerBackend.qml` | OpenVPN, WireGuard and OpenConnect, via NetworkManager |
 | `model/Shared.js` | Helpers every backend leans on, and the widget's own settings |
 | `model/Proton.js`, `model/Mullvad.js`, `model/Windscribe.js`, `model/NetworkManager.js` | Pure parsing and row-building, one file per tool. No QML, no side effects |
 
@@ -40,7 +40,7 @@ duck-types, so a backend that omits something simply renders as blank.
 |----------|---------|
 | `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `windscribe`, `networkmanager`) |
 | `label` | Name on the switcher chip and hero. Also what `preferredBackend` stores, so it must match that enum in `manifest.json` exactly |
-| `installNames` | What a user would install to make this backend useful, as a list. The panel joins them into its "install something" line when no tool is detected. Usually one name and the same as `label` — NetworkManager is the exception, offering `["OpenVPN", "WireGuard"]`, because nobody installs a connection manager to get a VPN |
+| `installNames` | What a user would install to make this backend useful, as a list. The panel joins them into its "install something" line when no tool is detected. Usually one name and the same as `label` — NetworkManager is the exception, offering `["OpenVPN", "WireGuard", "OpenConnect"]`, because nobody installs a connection manager to get a VPN |
 | `glyph` | Nerd Font character for the hero icon |
 | `supportsFilter`, `filterPlaceholder` | Whether the panel shows its filter field |
 | `filter` | The panel writes the current filter text here |
@@ -323,20 +323,36 @@ tunnel is down; the setting itself is read separately with
 `mullvad lockdown-mode get`, because the case that matters — Mullvad connected,
 another backend about to take over — is exactly when the payload omits it.
 
-**Why OpenVPN and WireGuard share one backend.** Same listing call, same
-`connection up` verb, same teardown, same secret-agent problem, and no settings
-of their own on either side. Two chips would have meant two views of one
-manager. NetworkManager types them differently — OpenVPN is a `vpn` connection
-with a service-type plugin behind it, WireGuard is its own connection type with
-the keys in the profile — and that difference is carried on each row as `kind`,
-which picks the glyph and decides whether the username check applies.
+**Why OpenVPN, WireGuard and OpenConnect share one backend.** Same listing call,
+same teardown, same secret-agent problem, and no settings of their own on any
+side. Three chips would have meant three views of one manager. NetworkManager
+types them differently — OpenVPN and OpenConnect are `vpn` connections with a
+service-type plugin behind them, WireGuard is its own connection type with the
+keys in the profile — and that difference is carried on each row as `kind`,
+which picks the glyph, decides whether the username check applies, and decides
+whether activation is an nmcli call at all.
+
+**Why OpenConnect needs a helper.** It is the one kind that cannot be brought
+up with `connection up`. Its `cookie`, `gateway`, `gwcert` and `resolve`
+secrets are all flagged not-saved, so every activation needs a secret agent to
+produce them, and `nmcli --ask` cannot stand in: it prompts for those four by
+name, and nobody can type a session cookie. What normally answers is nm-applet,
+whose whole contribution for OpenConnect is to run the auth dialog that
+networkmanager-openconnect ships and hand the results back.
+`bin/omarchy-openconnect-auth` does the same thing without the tray icon, so an
+OpenConnect target carries a whole `command` where the other kinds carry `args`
+for nmcli. The dialog is the same window the user already knows, which is the
+point: it is generated from the gateway's own XML and copes with Duo, cert
+prompts and form revisions that a reimplementation would break on.
 
 **NetworkManager discovery.** Two passes. `nmcli -t -f
 NAME,UUID,TYPE,ACTIVE,FILENAME connection show` gives every connection; the
 `vpn` and `wireguard` rows are kept. A second call over just the `vpn` uuids
-fetches `vpn.service-type` (to keep only OpenVPN ones) and `vpn.data` (to check
-for a username). WireGuard rows skip that pass entirely — they are already known
-to be WireGuard and have no username to be missing. The username matters because
+fetches `vpn.service-type` (which sorts OpenVPN from OpenConnect, and drops a
+third plugin's profile) and `vpn.data` (to check for a username, and to read
+the OpenConnect gateway). WireGuard rows skip that pass entirely — they are
+already known to be WireGuard and have no username to be missing. The username
+matters because
 NetworkManager keeps it outside the secrets store, so `nmcli --ask` never
 prompts for it — a profile without one authenticates as the empty user and the
 server answers `AUTH_FAILED`. The backend detects that case and reports the fix
@@ -351,7 +367,7 @@ anything can run it. With no eligible profile the backend disappears, and with
 it the chip, the hero, and the empty list they led to; the import instructions
 move to the panel's `setupHint` line so nothing is lost. Because `detected` now
 follows the profile list, the question is settled by `refresh()` rather than by
-`detect()`, which runs its three binary probes once and is a no-op after that.
+`detect()`, which runs its four probes once and is a no-op after that.
 
 **FILENAME is what keeps other tools' tunnels out.** When something brings up a
 WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -4,9 +4,10 @@ import "model/Shared.js" as Shared
 import "model/NetworkManager.js" as NetworkManager
 
 // NetworkManager backend: every tunnel NetworkManager owns, which on a desktop
-// means OpenVPN and WireGuard. Neither has a session daemon of its own to ask —
-// NetworkManager is what imports and stores both `.ovpn` files and WireGuard
-// configs. Implements the backend contract documented in VpnController.qml.
+// means OpenVPN, WireGuard and OpenConnect. None has a session daemon of its
+// own to ask — NetworkManager is what imports and stores `.ovpn` files,
+// WireGuard configs and AnyConnect profiles alike. Implements the backend
+// contract documented in VpnController.qml.
 Item {
   id: root
   visible: false
@@ -16,9 +17,15 @@ Item {
 
   readonly property string backendId: "networkmanager"
   readonly property string label: "NetworkManager"
-  // Two names, because this backend is the only way to reach either protocol
-  // and the label names the manager rather than anything you would install.
-  readonly property var installNames: ["OpenVPN", "WireGuard"]
+  // Three names, because this backend is the only way to reach any of the
+  // protocols and the label names the manager rather than anything you would
+  // install.
+  readonly property var installNames: ["OpenVPN", "WireGuard", "OpenConnect"]
+
+  // The helper that authenticates an OpenConnect profile. Resolved here
+  // because only the backend knows where the plugin is installed.
+  readonly property string openconnectAuth:
+    Qt.resolvedUrl("bin/omarchy-openconnect-auth").toString().replace(/^file:\/\//, "")
   readonly property string glyph: Shared.GLYPH_VPN
   readonly property bool supportsFilter: false
   readonly property string filterPlaceholder: ""
@@ -32,10 +39,12 @@ Item {
   // gets the chip, and a profile of a kind you cannot run simply never appears.
   property bool _openvpnPresent: false
   property bool _wireguardPresent: false
+  property bool _openconnectPresent: false
   property int _probesDone: 0
   property bool _probed: false
 
-  readonly property bool _toolsPresent: _nmcliPresent && (_openvpnPresent || _wireguardPresent)
+  readonly property bool _toolsPresent:
+    _nmcliPresent && (_openvpnPresent || _wireguardPresent || _openconnectPresent)
   // Having the tools is not having anything to connect to. NetworkManager is
   // the one backend whose list can be legitimately empty on a working install,
   // and a chip leading to an empty list is a chip worth not drawing.
@@ -62,7 +71,7 @@ Item {
   readonly property bool busy: _working || listProcess.running || typesProcess.running
   readonly property string summary: NetworkManager.nmSummary(profiles)
   readonly property var details: NetworkManager.nmDetails(profiles)
-  readonly property var targets: NetworkManager.nmTargets(profiles)
+  readonly property var targets: NetworkManager.nmTargets(profiles, root.openconnectAuth)
   readonly property string emptyText: "No profiles yet. Import one with: nmcli connection import type openvpn file <config.ovpn> — or type wireguard file <config.conf>"
   readonly property string currentKey: {
     var profile = NetworkManager.activeNmProfile(profiles)
@@ -81,17 +90,19 @@ Item {
   // poll a tool the user switched off. The binaries do not come and go, so once
   // probed this is nothing rather than three more processes every poll.
   function detect(force) {
-    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running) return
+    if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running
+        || openconnectProbe.running) return
     if (_probed && force !== true) return
     _probesDone = 0
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
+    openconnectProbe.running = true
   }
 
   function _probeFinished() {
     root._probesDone += 1
-    if (root._probesDone < 3) return
+    if (root._probesDone < 4) return
     root._probed = true
     if (root._toolsPresent) root.refresh()
   }
@@ -111,17 +122,30 @@ Item {
     // one — it lives in vpn.data. Without it the profile authenticates as the
     // empty user and the server rejects it, so point at the fix rather than
     // open a password prompt that cannot succeed. WireGuard has no username at
-    // all, so this is not its problem.
-    if (target.kind !== "wireguard" && target.hasUsername === false) {
+    // all, and OpenConnect settles identity with the gateway during its own
+    // authentication, so this is neither of their problems.
+    if (NetworkManager.needsUsername(target) && target.hasUsername === false) {
       lastError = "\"" + target.label + "\" has no username. Set one with: nmcli connection modify "
         + target.label + " +vpn.data username=<user>"
+      return
+    }
+
+    // An OpenConnect profile is unreachable without the auth dialog, and the
+    // helper is what finds it. Saying so beats an activation that fails with
+    // nmcli complaining about secrets nobody could have supplied.
+    if (target.kind === "openconnect" && !target.command) {
+      lastError = "\"" + target.label + "\" needs the OpenConnect auth dialog. Install networkmanager-openconnect."
       return
     }
 
     _desired = 1
     _pendingTarget = target
     lastError = ""
-    actionStatus = "Connecting to " + target.label + "…"
+    // OpenConnect waits on a person at a dialog rather than on the network, and
+    // that wait is unbounded — a Duo approval can sit on a phone for a minute.
+    actionStatus = target.kind === "openconnect"
+      ? "Authenticating with " + (target.gateway || target.label) + "…"
+      : "Connecting to " + target.label + "…"
 
     // NetworkManager will happily run two tunnels at once, and picking one
     // profile is never a request for both. The controller only enforces this
@@ -132,9 +156,17 @@ Item {
       connectProcess.command = ["nmcli", "connection", "down", "uuid", active.uuid]
     } else {
       _stage = "final"
-      connectProcess.command = ["nmcli"].concat(target.args || [])
+      connectProcess.command = root.activation(target)
     }
     connectProcess.running = true
+  }
+
+  // A target either names its own program or hands arguments to nmcli. Only
+  // OpenConnect does the former, because its activation runs the auth dialog
+  // first and cannot be spelled as an nmcli invocation.
+  function activation(target) {
+    if (target && target.command) return target.command
+    return ["nmcli"].concat((target && target.args) || [])
   }
 
   function connectPending() {
@@ -144,7 +176,7 @@ Item {
       return
     }
     root._stage = "final"
-    connectProcess.command = ["nmcli"].concat(target.args || [])
+    connectProcess.command = root.activation(target)
     connectProcess.running = true
   }
 
@@ -181,7 +213,9 @@ Item {
   // A profile is only eligible if the tool that carries its kind is installed:
   // NetworkManager lists an OpenVPN profile whether or not anything can run it.
   function runnable(profile) {
-    return profile.kind === "wireguard" ? _wireguardPresent : _openvpnPresent
+    if (profile.kind === "wireguard") return _wireguardPresent
+    if (profile.kind === "openconnect") return _openconnectPresent
+    return _openvpnPresent
   }
 
   function applyProfiles(list) {
@@ -257,6 +291,21 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._wireguardPresent = exitCode === 0
+      root._probeFinished()
+    }
+  }
+
+  // What OpenConnect needs is not a command on PATH but the auth dialog that
+  // networkmanager-openconnect ships, and distributions disagree about where
+  // that lives. The helper is asked, so the search exists in one place rather
+  // than being restated as a path here that could drift out of agreement with
+  // the connect that depends on it.
+  Process {
+    id: openconnectProbe
+    command: [root.openconnectAuth, "--dialog-path"]
+    running: true
+    onExited: function(exitCode) {
+      root._openconnectPresent = exitCode === 0
       root._probeFinished()
     }
   }
@@ -359,17 +408,27 @@ Item {
         var candidate = listProcess.pending[i]
 
         // WireGuard skipped the second pass, so it is kept as it stands. A
-        // `vpn` row survives only if OpenVPN is the plugin behind it — some
-        // other plugin's profile is not something this backend can drive.
+        // `vpn` row survives only if a plugin this backend can drive is behind
+        // it — some third plugin's profile is not something it can.
         if (candidate.kind === "wireguard") {
           usable.push(candidate)
           continue
         }
 
         var detail = details[candidate.uuid]
-        if (!detail || !NetworkManager.isOpenVpnService(detail.serviceType)) continue
+        if (!detail) continue
+
+        // The second pass is where a `vpn` row learns which plugin it is, so
+        // it is also where OpenConnect stops being indistinguishable from
+        // OpenVPN. Everything downstream keys off `kind`.
+        if (NetworkManager.isOpenConnectService(detail.serviceType)) {
+          candidate.kind = "openconnect"
+        } else if (!NetworkManager.isOpenVpnService(detail.serviceType)) {
+          continue
+        }
 
         candidate.hasUsername = detail.hasUsername
+        candidate.gateway = detail.gateway
         usable.push(candidate)
       }
       root.applyProfiles(usable)
@@ -398,7 +457,12 @@ Item {
       if (exitCode !== 0) {
         root._desired = -1
         var target = root._pendingTarget
-        if (root.missingSecrets(output) && target && target.uuid) {
+        // OpenConnect has already had its conversation, in the auth dialog the
+        // helper raised. Sending it to a terminal would offer `nmcli --ask`,
+        // which prompts for a session cookie and a certificate fingerprint by
+        // name — nothing a person can type. Its own failure is the honest one.
+        var interactive = target && target.kind !== "openconnect"
+        if (interactive && root.missingSecrets(output) && target.uuid) {
           root.lastError = "This profile needs credentials — opening a terminal to enter them."
           root.authRequired("nmcli --ask connection up uuid " + target.uuid)
         } else {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A VPN widget for the Omarchy bar. One icon shows whether you are behind a
 tunnel; one panel connects, disconnects, and switches between the VPN tools you
 actually have installed.
 
-It supports **Proton VPN**, **Mullvad**, **Windscribe**, and the **OpenVPN** and
+It supports **Proton VPN**, **Mullvad**, **Windscribe**, and the **OpenVPN**, **OpenConnect** and
 **WireGuard** profiles NetworkManager holds. Only the tools
 that have something to offer appear — install none and the widget tells you so;
 have several and a chip row lets you switch between them.
@@ -91,7 +91,8 @@ Omarchy with its Quickshell desktop, plus at least one of:
   (`mullvad account login <number>`).
 - **Windscribe** — `windscribe-cli` with the Windscribe app running, logged in
   (`windscribe-cli login`).
-- **OpenVPN or WireGuard** — `nmcli`, plus `openvpn` or `wg` (wireguard-tools),
+- **OpenVPN, WireGuard or OpenConnect** — `nmcli`, plus `openvpn`, `wg` (wireguard-tools),
+  or `networkmanager-openconnect`,
   with at least one profile imported into NetworkManager.
 
 ## Settings
@@ -221,6 +222,32 @@ lands in the same terminal.
 If you are importing a Proton `.ovpn`: the username and password are the
 **OpenVPN/IKEv2** credentials from your Proton dashboard, not your Proton
 account login.
+
+### OpenConnect
+
+OpenConnect profiles need none of the above, and cannot use it: their
+`cookie`, `gateway`, `gwcert` and `resolve` secrets are all flagged not-saved,
+so there is nothing to pre-save and `nmcli --ask` cannot help — it would prompt
+for a session cookie by name. Instead, picking the profile raises the auth
+dialog that `networkmanager-openconnect` ships, which is the same window
+nm-applet would have raised. Enter your password there, complete whatever second
+factor the gateway asks for, and the tunnel comes up. Install
+`networkmanager-openconnect` and the profile appears; nm-applet is not needed.
+
+**Give the dialog a floating rule.** It is a small GTK window, and tiled it
+lands as a ~240×270 tile among whatever else is on the workspace — which reads
+as the widget having done nothing, while the panel sits on "Authenticating…"
+and further clicks are ignored until that attempt finishes. In
+`~/.config/hypr/hyprland.lua`:
+
+```lua
+o.window("^(nm-openconnect-auth-dialog)$", { float = true, center = true })
+```
+
+**Let the dialog remember your password.** Tick "Save passwords" in it. That
+one setting does more than it looks like: `networkmanager-openconnect` also
+gates keyring storage and form auto-submission on it, so with it off every page
+of the form has to be clicked through by hand each time.
 
 ## Troubleshooting
 

--- a/bin/omarchy-openconnect-auth
+++ b/bin/omarchy-openconnect-auth
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Bring up a NetworkManager OpenConnect profile without nm-applet.
+#
+# NetworkManager holds openconnect's cookie/gateway/gwcert/resolve as "not
+# saved" secrets, so activating the profile needs a secret agent to produce
+# them every time. nm-applet is normally that agent; all it does for
+# openconnect is run the auth dialog below and hand the results back. This
+# does the same thing, so the bar can drive a connect with no tray icon.
+
+set -euo pipefail
+
+readonly SERVICE="org.freedesktop.NetworkManager.openconnect"
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+# networkmanager-openconnect does not agree with itself about where this lives:
+# Arch puts it in /usr/lib, Fedora in /usr/libexec, Debian under a multiarch
+# directory. Even on this machine the package's editor libraries sit in
+# /usr/lib/NetworkManager/ while the dialog is one level up, so there is no
+# single directory to point at.
+#
+# Runs in a command substitution, so it reports failure by exit code rather
+# than calling die: an exit from a subshell would not stop the caller, and the
+# caller would go on to report a second, contradictory reason.
+#   1  nothing found
+#   2  the override is set but unusable
+find_auth_dialog() {
+  local candidate
+
+  # -x alone is not enough: it is true of any searchable directory, so an
+  # override pointing at /tmp would be accepted and then fail to execute.
+  if [[ -n ${OMARCHY_OPENCONNECT_AUTH_DIALOG:-} ]]; then
+    [[ -f $OMARCHY_OPENCONNECT_AUTH_DIALOG && -x $OMARCHY_OPENCONNECT_AUTH_DIALOG ]] || return 2
+    printf '%s\n' "$OMARCHY_OPENCONNECT_AUTH_DIALOG"
+    return 0
+  fi
+
+  for candidate in \
+    /usr/lib/nm-openconnect-auth-dialog \
+    /usr/libexec/nm-openconnect-auth-dialog \
+    /usr/lib/NetworkManager/nm-openconnect-auth-dialog \
+    /usr/lib/networkmanager/nm-openconnect-auth-dialog \
+    /usr/lib/*/nm-openconnect-auth-dialog \
+    /usr/local/lib/nm-openconnect-auth-dialog; do
+    [[ -f $candidate && -x $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  done
+
+  return 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+usage: omarchy-openconnect-auth <name-or-uuid> [options]
+       omarchy-openconnect-auth --dialog-path
+
+  --dialog-path  print the auth dialog this would run and exit; fails if
+                 none is installed. Takes no connection.
+  --dry-run      print the auth-dialog payload and exit; runs no dialog,
+                 contacts no gateway
+  --probe        run the auth dialog and report which secrets came back,
+                 redacting the values; activates nothing
+  --blank-lines  separate DATA_KEY/DATA_VAL pairs with a blank line
+  --keep-open    leave the secrets file behind for inspection (insecure)
+
+Set OMARCHY_OPENCONNECT_AUTH_DIALOG to override dialog discovery.
+EOF
+  exit 64
+}
+
+target=""
+dry_run=0
+probe=0
+blank_lines=0
+keep_open=0
+show_dialog_path=0
+
+while (($#)); do
+  case "$1" in
+    --dialog-path) show_dialog_path=1 ;;
+    --dry-run) dry_run=1 ;;
+    --probe) probe=1 ;;
+    --blank-lines) blank_lines=1 ;;
+    --keep-open) keep_open=1 ;;
+    -h | --help) usage ;;
+    -*) die "unknown option: $1" ;;
+    *)
+      [[ -n $target ]] && die "only one connection may be given"
+      target="$1"
+      ;;
+  esac
+  shift
+done
+
+resolve_auth_dialog() {
+  local found status
+  found="$(find_auth_dialog)" && {
+    printf '%s\n' "$found"
+    return 0
+  }
+
+  status=$?
+  ((status == 2)) &&
+    die "OMARCHY_OPENCONNECT_AUTH_DIALOG is set but not executable: $OMARCHY_OPENCONNECT_AUTH_DIALOG"
+  die "no nm-openconnect-auth-dialog found (install networkmanager-openconnect)"
+}
+
+# The widget asks this to decide whether it can offer a connect at all, so the
+# search lives in one place instead of being restated in QML.
+if ((show_dialog_path)); then
+  resolve_auth_dialog
+  exit 0
+fi
+
+[[ -n $target ]] || usage
+
+AUTH_DIALOG="$(resolve_auth_dialog)"
+
+uuid="$(nmcli --get-values connection.uuid connection show "$target" 2>/dev/null)" ||
+  die "no such connection: $target"
+name="$(nmcli --get-values connection.id connection show uuid "$uuid")"
+service="$(nmcli --get-values vpn.service-type connection show uuid "$uuid")"
+
+[[ $service == "$SERVICE" ]] ||
+  die "\"$name\" is not an openconnect profile (vpn.service-type=$service)"
+
+# The dialog reads its own preferences out of the *secrets*, not the data:
+# whether to save passwords, which host was used last, whether to start
+# connecting without being asked. Sending only DATA_KEY left it with none of
+# them, which is why "Save passwords" came up unticked however many times it
+# had been ticked, and why the host was never remembered.
+#
+# Only these three are forwarded. The rest of the secrets are the credentials
+# the dialog is being run to *obtain* — a stale cookie is of no use to it and
+# could only confuse a fresh authentication. They are also long opaque blobs,
+# where the "key = value, ..." format nmcli prints stops being safe to split.
+readonly DIALOG_PREFS=(save_passwords lasthost autoconnect)
+
+# Reads one value out of that line without splitting the whole thing: anchored
+# at the start or at a ", " separator, and stopping at the next comma. Sound
+# for these three, whose values are yes/no and a hostname.
+saved_secret() {
+  local key="$1" secrets="$2"
+  [[ $secrets =~ (^|,[[:space:]])$key[[:space:]]*=[[:space:]]*([^,]*) ]] || return 1
+  printf '%s' "${BASH_REMATCH[2]}"
+}
+
+# vpn.data comes back as one line of "key = value" pairs joined by ", ".
+# openconnect's values are bare tokens (hostnames, yes/no, small integers), so
+# splitting on the separators is safe here in a way it would not be in general.
+build_payload() {
+  local data secrets pair key value sep=""
+  data="$(nmcli --get-values vpn.data connection show uuid "$uuid")"
+  secrets="$(nmcli --show-secrets --get-values vpn.secrets connection show uuid "$uuid" 2>/dev/null || true)"
+  ((blank_lines)) && sep=$'\n'
+
+  local IFS=,
+  for pair in $data; do
+    key="${pair%%=*}"
+    value="${pair#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    [[ -n $key ]] || continue
+    printf 'DATA_KEY=%s\nDATA_VAL=%s\n%s' "$key" "$value" "$sep"
+  done
+
+  # Secrets first, since that is where the dialog's own writes land, then
+  # vpn.data as a fallback: a preference can then be set with plain nmcli on a
+  # profile that has never been through the dialog, which is the only way to
+  # turn one on before the first connect. Either way it goes out as a secret,
+  # because that is the half the dialog reads.
+  unset IFS
+  for key in "${DIALOG_PREFS[@]}"; do
+    value="$(saved_secret "$key" "$secrets")" ||
+      value="$(saved_secret "$key" "$data")" ||
+      continue
+    [[ -n $value ]] || continue
+    printf 'SECRET_KEY=%s\nSECRET_VAL=%s\n%s' "$key" "$value" "$sep"
+  done
+
+  printf 'DONE\n'
+}
+
+payload="$(build_payload)"
+
+if ((dry_run)); then
+  # Command substitution has already eaten the newline after DONE, and the
+  # dialog reads its input a line at a time.
+  #
+  # SECRET_VAL is redacted. These three carry nothing worse than a hostname
+  # and a yes/no, but a dry run is a thing people paste into bug reports, and
+  # a payload dump should not be the one place secrets are allowed out.
+  printf '%s\n' "$payload" | sed -E 's/^SECRET_VAL=.*/SECRET_VAL=<redacted>/'
+  exit 0
+fi
+
+dialog_pid=""
+cleanup_dialog() {
+  [[ -n $dialog_pid ]] && kill "$dialog_pid" 2>/dev/null
+  return 0
+}
+trap cleanup_dialog EXIT INT TERM
+
+# The dialog is not a filter: it keeps a GIOChannel watch on stdin for the
+# whole session and expects a literal QUIT once it has emitted its secrets.
+# Handing it the payload down a pipe that then closes trips
+# "process_stdin: assertion 'status == G_IO_STATUS_NORMAL' failed" and strands
+# the window on screen with nothing left to read it. So stdin stays open, and
+# QUIT is what retires it.
+secret_keys=()
+secret_vals=()
+
+run_dialog() {
+  local key value out_fd in_fd
+
+  coproc DIALOG { "$AUTH_DIALOG" -u "$uuid" -n "$name" -s "$SERVICE" -i; }
+  dialog_pid="$DIALOG_PID"
+  out_fd="${DIALOG[0]}"
+  in_fd="${DIALOG[1]}"
+
+  printf '%s\n' "$payload" >&"$in_fd"
+
+  # Secrets arrive as key/value line pairs, terminated by a blank line.
+  while IFS= read -r key <&"$out_fd"; do
+    [[ -n $key ]] || break
+    IFS= read -r value <&"$out_fd" || break
+    secret_keys+=("$key")
+    secret_vals+=("$value")
+  done
+
+  printf 'QUIT\n' >&"$in_fd" 2>/dev/null || true
+  exec {in_fd}>&-
+  exec {out_fd}<&-
+
+  wait "$dialog_pid" 2>/dev/null || true
+  dialog_pid=""
+}
+
+run_dialog
+
+((${#secret_keys[@]})) ||
+  die "authentication was cancelled, or the dialog returned no secrets"
+
+# Write the dialog's own preferences back to the profile.
+#
+# Everything the dialog returns is handed to nmcli as an activation secret,
+# which NetworkManager uses and then forgets. That is right for the cookie and
+# wrong for these: ticking "Save passwords" had no lasting effect, because the
+# yes came back and went nowhere. And a save_passwords of "no" is not one
+# cosmetic checkbox — the dialog gates keyring storage on it, and gates
+# autosubmit on it too, so the whole form has to be clicked through by hand.
+#
+# Only the comma-free preferences are written. vpn.secrets is a dictionary
+# nmcli sets as one "k=v,k=v" string, with no escaping available, so a value
+# containing a comma would corrupt the rest -- which rules out xmlconfig and
+# certsigs. Both are only caches of what the gateway will send again anyway.
+persist_prefs() {
+  local i key pairs=()
+
+  for i in "${!secret_keys[@]}"; do
+    for key in "${DIALOG_PREFS[@]}"; do
+      [[ ${secret_keys[$i]} == "$key" ]] || continue
+      [[ ${secret_vals[$i]} == *,* ]] && continue
+      pairs+=("$key=${secret_vals[$i]}")
+    done
+  done
+
+  ((${#pairs[@]})) || return 0
+
+  # Setting vpn.secrets replaces the dictionary, so the credentials go with it.
+  # They are all flagged not-saved and re-fetched on every connect, so there is
+  # nothing there to keep.
+  local IFS=,
+  nmcli connection modify uuid "$uuid" vpn.secrets "${pairs[*]}" 2>/dev/null ||
+    printf 'warning: could not save the dialog preferences\n' >&2
+}
+
+# Not under --probe, which promises to change nothing.
+((probe)) || persist_prefs
+
+# A cookie is a live credential for as long as it lasts, so --probe reports the
+# shape of the reply and never a value: this output goes to a terminal, and
+# from there into scrollback and whatever is reading it.
+if ((probe)); then
+  printf 'auth dialog returned:\n'
+  for i in "${!secret_keys[@]}"; do
+    printf '  %-10s %d bytes\n' "${secret_keys[$i]}" "${#secret_vals[$i]}"
+  done
+  printf 'activated nothing\n'
+  exit 0
+fi
+
+runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+[[ -d $runtime ]] || die "no runtime directory at $runtime"
+
+umask 077
+pwfile="$(mktemp "$runtime/.omarchy-openconnect.XXXXXXXX")"
+((keep_open)) || trap 'rm -f "$pwfile"; cleanup_dialog' EXIT INT TERM
+
+# A live session cookie goes in a 0600 file on tmpfs, never in argv: every
+# process table on the machine can read /proc/<pid>/cmdline.
+for i in "${!secret_keys[@]}"; do
+  printf 'vpn.secrets.%s:%s\n' "${secret_keys[$i]}" "${secret_vals[$i]}" >>"$pwfile"
+done
+
+nmcli connection up uuid "$uuid" passwd-file "$pwfile"

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "VPN",
-    "description": "Detects installed VPN tools (Proton VPN, Mullvad, Windscribe, and NetworkManager's OpenVPN and WireGuard profiles) and switches between them from one bar icon.",
+    "description": "Detects installed VPN tools (Proton VPN, Mullvad, Windscribe, and NetworkManager's OpenVPN, WireGuard and OpenConnect profiles) and switches between them from one bar icon.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",

--- a/model/NetworkManager.js
+++ b/model/NetworkManager.js
@@ -5,11 +5,18 @@
 // the process plumbing lives in NetworkManagerBackend.qml.
 
 //
-// OpenVPN and WireGuard both live here, because on a desktop both are
-// NetworkManager profiles: same listing call, same `connection up` verb, same
-// teardown. What differs is how NetworkManager types them — OpenVPN is a `vpn`
-// connection with a service-type plugin behind it, WireGuard is its own
+// OpenVPN, WireGuard and OpenConnect all live here, because on a desktop all
+// three are NetworkManager profiles: same listing call, same teardown. What
+// differs is how NetworkManager types them — OpenVPN and OpenConnect are `vpn`
+// connections with a service-type plugin behind them, WireGuard is its own
 // connection type with the keys in the profile.
+//
+// OpenConnect differs from the other two in one way that reaches this file: it
+// cannot be brought up with `connection up` alone. Its cookie/gateway/gwcert/
+// resolve secrets are all flagged not-saved, so every activation needs a
+// secret agent to produce them, and the answer is a helper that runs the
+// openconnect auth dialog. That is why an OpenConnect target carries a whole
+// command rather than nmcli arguments.
 
 // `nmcli -t` escapes literal colons as "\:", so split on the first unescaped
 // one rather than on every colon.
@@ -77,7 +84,7 @@ function parseNmcliConnections(raw) {
 
 // `nmcli -t -f connection.uuid,vpn.service-type,vpn.data connection show <uuid>…`
 // prints one blank-line-separated block per connection, each line prefixed
-// with its field name. Returns { uuid: { serviceType, hasUsername } }.
+// with its field name. Returns { uuid: { serviceType, hasUsername, gateway } }.
 function parseNmcliVpnDetails(raw) {
   var details = {}
   var current = null
@@ -96,15 +103,33 @@ function parseNmcliVpnDetails(raw) {
     }
 
     var pair = splitNmcliLine(line)
-    if (!current) current = { uuid: "", serviceType: "", hasUsername: false }
+    if (!current) current = { uuid: "", serviceType: "", hasUsername: false, gateway: "" }
 
     if (pair[0] === "connection.uuid") current.uuid = pair[1]
     else if (pair[0] === "vpn.service-type") current.serviceType = pair[1]
-    else if (pair[0] === "vpn.data") current.hasUsername = hasVpnUsername(pair[1])
+    else if (pair[0] === "vpn.data") {
+      current.hasUsername = hasVpnUsername(pair[1])
+      current.gateway = vpnDataValue(pair[1], "gateway")
+    }
   }
   flush()
 
   return details
+}
+
+// One "key = value" out of vpn.data, matched on the whole key so that
+// `gateway-flags` is not mistaken for `gateway` — OpenConnect profiles carry
+// both, and the flags entry sorts first.
+function vpnDataValue(data, wanted) {
+  var entries = String(data || "").split(",")
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i]
+    var eq = entry.indexOf("=")
+    if (eq === -1) continue
+    if (entry.substring(0, eq).trim() !== wanted) continue
+    return entry.substring(eq + 1).trim()
+  }
+  return ""
 }
 
 // vpn.data is a comma-separated "key = value" list. OpenVPN's username lives
@@ -126,36 +151,76 @@ function isOpenVpnService(serviceType) {
   return String(serviceType || "").toLowerCase().indexOf("openvpn") !== -1
 }
 
+// "openconnect" does not contain "openvpn", so the two checks cannot both
+// claim the same profile.
+function isOpenConnectService(serviceType) {
+  return String(serviceType || "").toLowerCase().indexOf("openconnect") !== -1
+}
+
 function isWireGuard(profile) {
   return profile && profile.kind === "wireguard"
 }
 
+function isOpenConnect(profile) {
+  return profile && profile.kind === "openconnect"
+}
+
+// A username is an OpenVPN concern only. WireGuard keeps its keys in the
+// profile, and OpenConnect asks the gateway who you are as part of its own
+// authentication, so neither can be missing one.
+function needsUsername(profile) {
+  return !isWireGuard(profile) && !isOpenConnect(profile)
+}
+
 function nmKindLabel(profile) {
-  return isWireGuard(profile) ? "WireGuard" : "OpenVPN"
+  if (isWireGuard(profile)) return "WireGuard"
+  if (isOpenConnect(profile)) return "OpenConnect"
+  return "OpenVPN"
 }
 
 // The glyph carries the kind, since the rows otherwise look identical and the
-// two behave differently the moment credentials come up.
-function nmTargets(profiles) {
+// three behave differently the moment credentials come up.
+//
+// `authScript` is the openconnect helper's absolute path, which only the
+// backend knows. An OpenConnect target gets a `command` — a whole argv — where
+// the others get `args` to hand to nmcli, because its activation is not an
+// nmcli call. Without the helper an OpenConnect row is still listed and still
+// says what it is, but has nothing to run.
+function nmTargets(profiles, authScript) {
   var targets = []
   for (var i = 0; i < profiles.length; i++) {
     var profile = profiles[i]
     var wireguard = isWireGuard(profile)
+    var openconnect = isOpenConnect(profile)
 
-    targets.push({
+    var glyph = Shared.GLYPH_LOCK
+    if (wireguard) glyph = Shared.GLYPH_SHIELD
+    else if (openconnect) glyph = Shared.GLYPH_SHIELD_LOCK
+
+    var target = {
       key: "profile:" + profile.uuid,
       label: profile.name,
       detail: profile.active
         ? "Connected"
         // Only OpenVPN can be missing a username: WireGuard keeps its keys in
-        // the profile, so there is nothing for the user to have left out.
-        : (wireguard || profile.hasUsername ? nmKindLabel(profile) + " profile" : "No username set"),
-      glyph: wireguard ? Shared.GLYPH_SHIELD : Shared.GLYPH_LOCK,
+        // the profile, and OpenConnect settles identity with the gateway, so
+        // neither has anything for the user to have left out.
+        : (!needsUsername(profile) || profile.hasUsername
+            ? nmKindLabel(profile) + " profile"
+            : "No username set"),
+      glyph: glyph,
       args: ["connection", "up", "uuid", profile.uuid],
       uuid: profile.uuid,
       kind: profile.kind,
-      hasUsername: profile.hasUsername
-    })
+      hasUsername: profile.hasUsername,
+      gateway: profile.gateway || ""
+    }
+
+    if (openconnect && String(authScript || "") !== "") {
+      target.command = [String(authScript), profile.uuid]
+    }
+
+    targets.push(target)
   }
   return targets
 }
@@ -173,6 +238,11 @@ function nmDetails(profiles) {
     if (!profiles[i].active) continue
     rows.push(Shared.detail("Profile", profiles[i].name))
     rows.push(Shared.detail("Type", nmKindLabel(profiles[i])))
+    // Which gateway an OpenConnect profile reached, since a company commonly
+    // has several and the profile name rarely says which one.
+    if (isOpenConnect(profiles[i]) && profiles[i].gateway) {
+      rows.push(Shared.detail("Gateway", profiles[i].gateway))
+    }
   }
   if (rows.length > 0) rows.push(Shared.detail("Managed by", "NetworkManager"))
   return rows

--- a/model/Shared.js
+++ b/model/Shared.js
@@ -13,6 +13,10 @@ var GLYPH_BOLT = String.fromCodePoint(0xF04C5)
 var GLYPH_DICE = String.fromCodePoint(0xF01D5)
 var GLYPH_SWAP = String.fromCodePoint(0xF04E1)
 var GLYPH_SHIELD = String.fromCodePoint(0xF0498)
+// A shield with a lock in it: reads as neither the bare shield WireGuard uses
+// nor the bare padlock OpenVPN does, which is the point — the three sit next
+// to each other in the same list.
+var GLYPH_SHIELD_LOCK = String.fromCodePoint(0xF099D)
 var GLYPH_CHEVRON_DOWN = String.fromCodePoint(0xF0140)
 var GLYPH_CHEVRON_UP = String.fromCodePoint(0xF0143)
 var GLYPH_COG = String.fromCodePoint(0xF0493)

--- a/tests/model/networkmanager.test.js
+++ b/tests/model/networkmanager.test.js
@@ -73,6 +73,100 @@ test("nmTargets flags an OpenVPN profile with no username", () => {
   eq(targets[0].args, ["connection", "up", "uuid", "uuid-1"])
 })
 
+// ------------------------------------------------------------- OpenConnect
+
+// Real `nmcli -t -f connection.uuid,vpn.service-type,vpn.data connection show`
+// output for an AnyConnect profile. Note `gateway-flags` sorts before
+// `gateway`, and the four not-saved flags that are the whole reason this kind
+// cannot be brought up with `connection up` alone.
+const OPENCONNECT_DETAILS = [
+  "connection.uuid:uuid-oc",
+  "vpn.service-type:org.freedesktop.NetworkManager.openconnect",
+  "vpn.data:authtype = password, cookie-flags = 2, gateway = vpn.example.com, gateway-flags = 2, gwcert-flags = 2, protocol = anyconnect, resolve-flags = 2",
+  ""
+].join("\n")
+
+test("isOpenConnectService tells the plugins apart", () => {
+  eq(NetworkManager.isOpenConnectService("org.freedesktop.NetworkManager.openconnect"), true)
+  eq(NetworkManager.isOpenConnectService("org.freedesktop.NetworkManager.openvpn"), false)
+  eq(NetworkManager.isOpenConnectService(""), false)
+  // Neither name contains the other, so no profile can answer to both.
+  eq(NetworkManager.isOpenVpnService("org.freedesktop.NetworkManager.openconnect"), false)
+})
+
+test("parseNmcliVpnDetails reads an OpenConnect profile's gateway", () => {
+  const details = NetworkManager.parseNmcliVpnDetails(OPENCONNECT_DETAILS)
+  eq(NetworkManager.isOpenConnectService(details["uuid-oc"].serviceType), true)
+  eq(details["uuid-oc"].gateway, "vpn.example.com")
+})
+
+// `gateway-flags` appears first in vpn.data and starts with the same text, so a
+// prefix match would return "2" and the panel would name the gateway as a
+// number.
+test("vpnDataValue matches the whole key, not a prefix", () => {
+  eq(NetworkManager.vpnDataValue("gateway-flags = 2, gateway = vpn.example.com", "gateway"), "vpn.example.com")
+  eq(NetworkManager.vpnDataValue("gateway-flags = 2", "gateway"), "")
+  eq(NetworkManager.vpnDataValue("", "gateway"), "")
+})
+
+test("nmKindLabel names all three kinds", () => {
+  eq(NetworkManager.nmKindLabel({ kind: "wireguard" }), "WireGuard")
+  eq(NetworkManager.nmKindLabel({ kind: "openconnect" }), "OpenConnect")
+  eq(NetworkManager.nmKindLabel({ kind: "vpn" }), "OpenVPN")
+})
+
+// A username is an OpenVPN concern. OpenConnect settles identity with the
+// gateway during its own authentication, so demanding one would block a
+// profile that is perfectly connectable.
+test("nmTargets never asks an OpenConnect profile for a username", () => {
+  const targets = NetworkManager.nmTargets([
+    { name: "Work", uuid: "uuid-oc", kind: "openconnect", active: false, hasUsername: false }
+  ], "/plugins/vpn/bin/omarchy-openconnect-auth")
+  eq(targets[0].detail, "OpenConnect profile")
+  eq(targets[0].glyph, Shared.GLYPH_SHIELD_LOCK)
+})
+
+// Its activation is not an nmcli call, so it carries a whole command. The other
+// kinds must keep handing nmcli arguments.
+test("nmTargets gives an OpenConnect target the helper as its command", () => {
+  const targets = NetworkManager.nmTargets([
+    { name: "Work", uuid: "uuid-oc", kind: "openconnect", active: false, gateway: "vpn.example.com" },
+    { name: "Home", uuid: "uuid-wg", kind: "wireguard", active: false }
+  ], "/plugins/vpn/bin/omarchy-openconnect-auth")
+  eq(targets[0].command, ["/plugins/vpn/bin/omarchy-openconnect-auth", "uuid-oc"])
+  eq(targets[0].gateway, "vpn.example.com")
+  eq(targets[1].command, undefined)
+  eq(targets[1].args, ["connection", "up", "uuid", "uuid-wg"])
+})
+
+// Without the helper the row is still listed and still says what it is; it
+// simply has nothing to run, which the backend checks before connecting.
+test("nmTargets omits the command when the helper is unknown", () => {
+  const targets = NetworkManager.nmTargets([
+    { name: "Work", uuid: "uuid-oc", kind: "openconnect", active: false }
+  ])
+  eq(targets[0].command, undefined)
+  eq(targets[0].detail, "OpenConnect profile")
+})
+
+test("nmDetails names the gateway for a live OpenConnect tunnel", () => {
+  const rows = NetworkManager.nmDetails([
+    { name: "Work", uuid: "uuid-oc", kind: "openconnect", active: true, gateway: "vpn.example.com" }
+  ])
+  eq(rows[1], Shared.detail("Type", "OpenConnect"))
+  eq(rows[2], Shared.detail("Gateway", "vpn.example.com"))
+})
+
+// OpenVPN and WireGuard have no gateway field, and an empty row would read as
+// a missing value rather than an inapplicable one.
+test("nmDetails adds no gateway row for the other kinds", () => {
+  const rows = NetworkManager.nmDetails([
+    { name: "Home", uuid: "uuid-wg", kind: "wireguard", active: true }
+  ])
+  eq(rows.length, 3)
+  eq(rows[2], Shared.detail("Managed by", "NetworkManager"))
+})
+
 test("nmSummary tells no profiles from none connected", () => {
   eq(NetworkManager.nmSummary([]), "No profiles")
   eq(NetworkManager.nmSummary([{ name: "Work", active: false }]), "Not connected")


### PR DESCRIPTION
Hello!

This adds support for the OpenConnect protocol in NetworkManager

<img width="531" height="447" alt="image" src="https://github.com/user-attachments/assets/957e27bc-4219-4304-a25b-12f246675b09" />


Thanks!