### PR TITLE
fix: Proton runs the CLI one invocation at a time, behind a shared lock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,6 +177,35 @@ every 15 seconds for the life of the shell. `protonAuthRequired` tells that
 refusal apart from a tool that is unwell, `signedOut` latches it, and the panel
 says `protonvpn signin` instead of `Loading countries…` forever.
 
+**Two `protonvpn` processes must never overlap.** Proton's client library is
+undocumentedly unsafe to invoke concurrently: each process loads the stored
+session — refresh token included — at startup and never re-reads it, and Proton
+rotates that token single-use. Two invocations straddling a token refresh means
+the winner spends the token and persists its replacement while the loser posts
+the one just spent; `/auth/refresh` answers 400, and proton-core reads a 400
+there as *this session is finished* and deletes it from the keyring, silently.
+What the user sees is Proton VPN signing itself out, usually noticed after a
+reboot ([#23](https://github.com/jkoestinger/omarchy-vpn/issues/23)).
+
+No guard inside the widget can prevent that, because the bar instantiates the
+widget once per monitor: three monitors are three copies of this backend on
+three timers, each blind to the others. A kernel file lock is not blind to them,
+so `protonCli()` wraps every invocation in `flock` on one file under
+`XDG_RUNTIME_DIR`, and the six call sites — status, config, countries, connect,
+disconnect, toggles — all go through it. `-w 60` rather than an unbounded wait,
+so a wedged CLI costs one poll instead of every poll after it.
+
+The lock makes overlap impossible; it does not make it cheap. Three reads
+started at once become a queue three deep per instance, long enough that one
+tick's commands are still draining when the next tick adds three more. So the
+poll asks for one thing at a time and starts the next from the previous one's
+exit — `protonNextRead()` decides which, `_pump()` runs it, and `_cliBusy` is
+what "this instance already has a call out" means. Nothing starts a process from
+inside another's `onExited`, because `running` has not gone false there yet;
+`pumpTimer` puts it one turn of the event loop later, which also collapses two
+exits landing together into one decision. A dropped chain is not fatal: the
+controller's next `refresh()` starts a new one.
+
 **Settings are read, never owned.** `toggles` always reports what the tool
 itself last said, and the widget stores no copy — nothing in `manifest.json`
 asserts a desired value at startup. Turning lockdown on from the Mullvad CLI

--- a/ProtonBackend.qml
+++ b/ProtonBackend.qml
@@ -110,34 +110,56 @@ Item {
   // the first thing a probe wants is an answer.
   property bool _statusDue: true
 
+  // Anything this backend runs, including the user's connects and toggles.
+  // Every one of them queues behind the same lock, so the useful question is
+  // never "is this process free" but "is this instance already holding a slot".
+  readonly property bool _cliBusy: statusProcess.running || configProcess.running
+    || countriesProcess.running || connectProcess.running || toggleProcess.running
+
   // Every non-hidden backend is polled on the interval whether or not the panel
   // is open, and `protonvpn` is Python: each invocation costs the best part of a
   // CPU-second before it does any work. So the poll asks for the status alone
   // once the other two have been answered, and asks for that on the cadence
-  // above rather than on every tick. Both of the others need an account, so
-  // signed out they are not asked at all.
+  // above rather than on every tick.
   function refresh() {
     if (!detected) return
 
     _sinceStatus += 1
     if (_statusEvery > 0 && _sinceStatus >= _statusEvery) _statusDue = true
 
-    if (_statusDue && !statusProcess.running) {
+    _pump()
+  }
+
+  // Starts the one read the poll owes next, if this instance has nothing out.
+  // Every read ends by asking again, so the tick's work drains as a chain; the
+  // controller's next refresh() is only what restarts a chain that ended.
+  function _pump() {
+    if (!detected) return
+
+    var next = Proton.protonNextRead({
+      busy: _cliBusy,
+      statusDue: _statusDue,
+      signedOut: signedOut,
+      configLoaded: _configLoaded,
+      countriesLoaded: countriesLoaded
+    })
+
+    if (next === "status") {
       _statusDue = false
       _sinceStatus = 0
       statusProcess.running = true
+    } else if (next === "config") {
+      configProcess.running = true
+    } else if (next === "countries") {
+      countriesProcess.running = true
     }
-
-    if (signedOut) return
-    if (!_configLoaded && !configProcess.running) configProcess.running = true
-    if (!countriesLoaded && !countriesProcess.running) countriesProcess.running = true
   }
 
   // For the paths that have just changed something and need to see it land. The
   // cadence is for the idle case; a settling action is not one.
   function refreshNow() {
     _statusDue = true
-    refresh()
+    pumpTimer.restart()
   }
 
   // Latches the signed-out state from a refusal, and answers "was that a
@@ -168,7 +190,7 @@ Item {
 
     lastError = ""
     _toggleKey = key
-    toggleProcess.command = ["protonvpn"].concat(args)
+    toggleProcess.command = Proton.protonCli(args)
     toggleProcess.running = true
     pendingTimer.restart()
   }
@@ -209,7 +231,7 @@ Item {
     _desired = 1
     lastError = ""
     actionStatus = "Connecting to " + target.label + "…"
-    connectProcess.command = ["protonvpn", "connect"].concat(target.args || [])
+    connectProcess.command = Proton.protonCli(["connect"].concat(target.args || []))
     connectProcess.running = true
   }
 
@@ -218,7 +240,7 @@ Item {
     _desired = 0
     lastError = ""
     actionStatus = "Disconnecting…"
-    connectProcess.command = ["protonvpn", "disconnect"]
+    connectProcess.command = Proton.protonCli(["disconnect"])
     connectProcess.running = true
   }
 
@@ -247,6 +269,18 @@ Item {
       root._pendingToggles = ({})
       root.lastError = "Proton VPN did not apply that setting."
     }
+  }
+
+  // Nothing may start a `protonvpn` from inside another one's onExited: that
+  // process is still running as far as `running` is concerned, so _pump would
+  // read the instance as busy and drop the rest of the chain until the next
+  // tick. One turn of the event loop later it has settled, and two exits
+  // landing together collapse into one decision rather than two.
+  Timer {
+    id: pumpTimer
+    interval: 0
+    repeat: false
+    onTriggered: root._pump()
   }
 
   // The CLI reports the new state a beat after the command returns, so re-poll
@@ -282,7 +316,7 @@ Item {
   Process {
     id: statusProcess
     running: false
-    command: ["protonvpn", "status"]
+    command: Proton.protonCli(["status"])
     stdout: StdioCollector { id: statusStdout; waitForEnd: true }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true }
     onExited: function(exitCode) {
@@ -294,6 +328,7 @@ Item {
       } else {
         root.lastError = Shared.elide(String(statusStderr.text || statusStdout.text || "") || "Could not read Proton VPN status", 140)
       }
+      pumpTimer.restart()
     }
   }
 
@@ -325,17 +360,17 @@ Item {
   Process {
     id: configProcess
     running: false
-    command: ["protonvpn", "config", "list"]
+    command: Proton.protonCli(["config", "list"])
     stdout: StdioCollector { id: configStdout; waitForEnd: true }
     stderr: StdioCollector { id: configStderr; waitForEnd: true }
     onExited: function(exitCode) {
       var out = String(configStdout.text || "")
-      if (root.noteAuth(exitCode, out, String(configStderr.text || ""))) return
+      var refusedConfig = root.noteAuth(exitCode, out, String(configStderr.text || ""))
       // Answered either way: a table this parser cannot read is a reason to show
       // no switches, not to re-read it on every poll for the life of the shell.
-      root._configLoaded = true
-      if (exitCode !== 0) return
-      root.applyConfig(out)
+      if (!refusedConfig) root._configLoaded = true
+      if (exitCode === 0) root.applyConfig(out)
+      pumpTimer.restart()
     }
   }
 
@@ -352,7 +387,10 @@ Item {
         root.clearPending(root._toggleKey)
       }
       root._toggleKey = ""
-      if (!configProcess.running) configProcess.running = true
+      // Re-read the switches: the tool's answer is the only one this backend
+      // shows. Through the chain, so it queues rather than racing the poll.
+      root._configLoaded = false
+      pumpTimer.restart()
     }
   }
 
@@ -362,22 +400,26 @@ Item {
   Process {
     id: countriesProcess
     running: false
-    command: ["protonvpn", "countries", "list"]
+    command: Proton.protonCli(["countries", "list"])
     stdout: StdioCollector { id: countriesStdout; waitForEnd: true }
     stderr: StdioCollector { id: countriesStderr; waitForEnd: true }
     onExited: function(exitCode) {
       var out = String(countriesStdout.text || "")
       var err = String(countriesStderr.text || "")
-      if (root.noteAuth(exitCode, out, err)) return
+      if (root.noteAuth(exitCode, out, err)) {
+        pumpTimer.restart()
+        return
+      }
 
       var unreadable = "Could not read the country list. Check: protonvpn countries list"
       root.countriesLoaded = true
       if (exitCode !== 0) {
         root.lastError = Shared.elide(err || out || unreadable, 140)
-        return
+      } else {
+        root.countries = Proton.parseProtonCountries(out)
+        if (root.countries.length === 0) root.lastError = unreadable
       }
-      root.countries = Proton.parseProtonCountries(out)
-      if (root.countries.length === 0) root.lastError = unreadable
+      pumpTimer.restart()
     }
   }
 }

--- a/model/Proton.js
+++ b/model/Proton.js
@@ -4,6 +4,55 @@
 // Proton VPN, via the `protonvpn` CLI. Parsing and row-building only — the
 // process plumbing lives in ProtonBackend.qml.
 
+// Two `protonvpn` processes must never overlap. Each one loads the stored
+// session — including its refresh token — at startup and never re-reads it, and
+// Proton rotates that token single-use. So when two of them straddle a token
+// refresh, the winner trades the token and persists the new one, the loser
+// posts the token that was just spent, `/auth/refresh` answers 400, and
+// proton-core reads a 400 there as "this session is finished" and deletes it
+// from the keyring. Nothing is logged. The user sees Proton VPN signing itself
+// out, usually noticing after a reboot.
+//
+// Nothing inside one widget can prevent that: the bar instantiates the widget
+// once per monitor, so a three-monitor desktop is three copies of this backend
+// polling on their own timers, and a QML guard is invisible to the other two.
+// A kernel file lock is not, so every invocation goes through one.
+// XDG_RUNTIME_DIR is where it belongs — per-user, and cleared at logout — with
+// the cache directory as a fallback for a session that somehow has no runtime
+// dir. `-w 60` rather than an unbounded wait, so a wedged CLI costs one poll
+// instead of every poll after it; `exec` so no shell sits around for the
+// duration of a Python start.
+var PROTON_CLI_LOCK = "${XDG_RUNTIME_DIR:-$HOME/.cache}/omarchy-vpn-protonvpn.lock"
+
+function protonCli(args) {
+  return [
+    "sh", "-c",
+    'exec flock -w 60 "' + PROTON_CLI_LOCK + '" protonvpn "$@"',
+    // $0. `sh -c script name a b` puts a and b in "$@", and names the shell.
+    "protonvpn"
+  ].concat(args || [])
+}
+
+// Which of the poll's three reads to start now. They used to start together;
+// with the lock above that only buys a queue three deep per monitor, which is
+// long enough for one tick's commands to still be draining when the next tick
+// adds three more. One at a time, each started by the previous one's exit,
+// keeps the queue to one entry per instance.
+//
+// Order is what the panel wants first: the chip needs the status, the switches
+// need the config, the rows need the country list.
+function protonNextRead(state) {
+  var known = state || {}
+  if (known.busy) return ""
+  if (known.statusDue) return "status"
+  // Both of the others need an account, and a signed-out CLI refuses forever —
+  // see protonAuthRequired.
+  if (known.signedOut) return ""
+  if (!known.configLoaded) return "config"
+  if (!known.countriesLoaded) return "countries"
+  return ""
+}
+
 // `protonvpn status` prints a plain-text block, not JSON:
 //
 //   Status: Connected

--- a/tests/model/proton.test.js
+++ b/tests/model/proton.test.js
@@ -130,3 +130,38 @@ test("protonAuthRequired reads the CLI's refusals", () => {
   eq(Proton.protonAuthRequired("Error: could not reach the Proton VPN API"), false)
   eq(Proton.protonAuthRequired("Status: Disconnected"), false)
 })
+
+// Two overlapping `protonvpn` processes destroy the stored session (see
+// protonCli), so the shape of the argv matters as much as the arguments in it.
+test("protonCli queues every invocation behind one lock", () => {
+  const command = Proton.protonCli(["connect", "NL"])
+  eq(command[0], "sh")
+  eq(command[1], "-c")
+  eq(command[2], 'exec flock -w 60 "${XDG_RUNTIME_DIR:-$HOME/.cache}/omarchy-vpn-protonvpn.lock" protonvpn "$@"')
+  // $0 names the shell; the CLI's own arguments start at $1.
+  eq(command.slice(3), ["protonvpn", "connect", "NL"])
+})
+
+test("protonCli takes no arguments as a bare subcommandless call", () => {
+  eq(Proton.protonCli([]).length, 4)
+  eq(Proton.protonCli().length, 4)
+})
+
+test("protonNextRead asks for one thing at a time, status first", () => {
+  const owed = { statusDue: true, configLoaded: false, countriesLoaded: false }
+  eq(Proton.protonNextRead(owed), "status")
+  eq(Proton.protonNextRead(Object.assign({}, owed, { statusDue: false })), "config")
+  eq(Proton.protonNextRead({ configLoaded: true }), "countries")
+  eq(Proton.protonNextRead({ configLoaded: true, countriesLoaded: true }), "")
+})
+
+test("protonNextRead starts nothing while this instance has a call out", () => {
+  eq(Proton.protonNextRead({ busy: true, statusDue: true }), "")
+})
+
+// A signed-out CLI refuses both of these for as long as nobody signs in, and
+// each refusal costs a Python start.
+test("protonNextRead stops asking for what needs an account when signed out", () => {
+  eq(Proton.protonNextRead({ signedOut: true }), "")
+  eq(Proton.protonNextRead({ signedOut: true, statusDue: true }), "status")
+})


### PR DESCRIPTION
Fixes #23.

## The bug

Proton's client library is undocumentedly unsafe to invoke concurrently. Each `protonvpn` process loads the stored session — refresh token included — at startup and never re-reads it, and Proton rotates that token single-use. Two invocations straddling a token refresh means the winner spends the token and persists its replacement while the loser posts the one just spent; `/auth/refresh` answers 400, and proton-core reads a 400 there as *this session is finished* and deletes it from the keyring. Nothing is logged. What the user sees is Proton VPN signing itself out, usually noticed after a reboot.

`refresh()` started `statusProcess`, `configProcess` and `countriesProcess` together on every poll tick, and the bar instantiates the widget once per monitor — so a three-monitor desktop fired nine `protonvpn` invocations at roughly the same moment, every tick.

Full credit to @SisyphusOfCorinth for the diagnosis and the shape of the fix.

## The fix

**A kernel file lock, because no QML guard spans monitors.** `Proton.protonCli()` wraps every invocation:

```sh
sh -c 'exec flock -w 60 "${XDG_RUNTIME_DIR:-$HOME/.cache}/omarchy-vpn-protonvpn.lock" protonvpn "$@"' protonvpn <args>
```

All six call sites go through it — status, config, countries, connect, disconnect, toggles. `-w 60` rather than an unbounded wait, so a wedged CLI costs one poll instead of every poll after it; `exec` so no shell sits around for the duration of a Python start.

**One invocation at a time per instance, so the queue stays short.** The lock makes overlap impossible; it does not make it cheap. Three reads started at once become a queue three deep per instance, long enough that one tick's commands are still draining when the next tick adds three more. So the poll asks for one thing and starts the next from the previous one's exit — `protonNextRead()` decides which, `_pump()` runs it, `_cliBusy` means "this instance already has a call out".

`pumpTimer` (interval 0) is why the chain does not break: `running` has not gone false inside a process's own `onExited`, so pumping from there would read the instance as busy and drop the rest of the chain until the next tick. One turn of the event loop later it has settled, and two exits landing together collapse into one decision. A dropped chain is not fatal either — the controller's next `refresh()` starts a new one.

`toggleProcess` now clears `_configLoaded` and pumps rather than poking `configProcess` directly, so its re-read queues instead of racing the poll.

## Notes on the two deliberate deviations from the issue

- **Lock fallback is `$HOME/.cache`, not `/tmp`.** `XDG_RUNTIME_DIR` is set in every systemd user session so the fallback is defensive only, but a `/tmp` lock owned by another user makes `flock` fail to open it and the command never runs at all. `$HOME/.cache` is per-user by construction. The name is prefixed `omarchy-vpn-` so it cannot collide with anything Proton itself puts there.
- **Sequencing lives in `model/Proton.js`, not the QML.** Per AGENTS.md, anything resembling a decision belongs in the model file — which is also the only half that runs under test.

## Verification

- `node tests/run.js` — 78 passed, 0 failed (6 new cases covering the argv shape, `$0` not leaking into `"$@"`, the read order, the busy guard, and the signed-out case).
- `qmllint -I /usr/share/omarchy/shell jkoestinger.vpn/ProtonBackend.qml` — clean.
- Shell-level check that the lock actually serializes three concurrent invocations: strict `start`/`end` pairs, no interleaving.
- Live on a two-monitor machine after `omarchy restart shell`: sampling `pgrep -af protonvpn` every 50 ms for 75 s gave 1050 samples with zero `protonvpn` python processes and 24 with exactly one. **Never two.** Waiting `flock` processes do appear in pairs, which is the queue working as intended.

ARCHITECTURE.md gets three paragraphs in the Proton section covering the token mechanism, why the lock has to be a kernel one, and the chaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
