### PR TITLE
feat: add NetworkManager VPNC profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ surrounding workflow.
 | `ProtonBackend.qml` | Proton VPN, via the `protonvpn` CLI |
 | `MullvadBackend.qml` | Mullvad, via the `mullvad` CLI |
 | `WindscribeBackend.qml` | Windscribe, via `windscribe-cli` |
-| `NetworkManagerBackend.qml` | OpenVPN, WireGuard and OpenConnect, via NetworkManager |
+| `NetworkManagerBackend.qml` | OpenVPN, WireGuard, OpenConnect and VPNC, via NetworkManager |
 | `model/Shared.js` | Helpers every backend leans on, and the widget's own settings |
 | `model/Proton.js`, `model/Mullvad.js`, `model/Windscribe.js`, `model/NetworkManager.js` | Pure parsing and row-building, one file per tool. No QML, no side effects |
 
@@ -40,7 +40,7 @@ duck-types, so a backend that omits something simply renders as blank.
 |----------|---------|
 | `backendId` | Stable key used by settings and IPC (`proton`, `mullvad`, `windscribe`, `networkmanager`) |
 | `label` | Name on the switcher chip and hero. Also what `preferredBackend` stores, so it must match that enum in `manifest.json` exactly |
-| `installNames` | What a user would install to make this backend useful, as a list. The panel joins them into its "install something" line when no tool is detected. Usually one name and the same as `label` — NetworkManager is the exception, offering `["OpenVPN", "WireGuard", "OpenConnect"]`, because nobody installs a connection manager to get a VPN |
+| `installNames` | What a user would install to make this backend useful, as a list. The panel joins them into its "install something" line when no tool is detected. Usually one name and the same as `label` — NetworkManager is the exception, offering `["OpenVPN", "WireGuard", "OpenConnect", "VPNC"]`, because nobody installs a connection manager to get a VPN |
 | `glyph` | Nerd Font character for the hero icon |
 | `supportsFilter`, `filterPlaceholder` | Whether the panel shows its filter field |
 | `filter` | The panel writes the current filter text here |
@@ -352,14 +352,14 @@ tunnel is down; the setting itself is read separately with
 `mullvad lockdown-mode get`, because the case that matters — Mullvad connected,
 another backend about to take over — is exactly when the payload omits it.
 
-**Why OpenVPN, WireGuard and OpenConnect share one backend.** Same listing call,
-same teardown, same secret-agent problem, and no settings of their own on any
-side. Three chips would have meant three views of one manager. NetworkManager
-types them differently — OpenVPN and OpenConnect are `vpn` connections with a
-service-type plugin behind them, WireGuard is its own connection type with the
-keys in the profile — and that difference is carried on each row as `kind`,
-which picks the glyph, decides whether the username check applies, and decides
-whether activation is an nmcli call at all.
+**Why OpenVPN, WireGuard, OpenConnect and VPNC share one backend.** Same listing
+call, same teardown, same secret-agent problem, and no settings of their own on
+any side. Four chips would have meant four views of one manager. NetworkManager
+types them differently — OpenVPN, OpenConnect and VPNC are `vpn` connections
+with a service-type plugin behind them, while WireGuard is its own connection
+type with the keys in the profile — and that difference is carried on each row
+as `kind`, which picks the glyph, decides which username key applies, and
+decides whether activation is an nmcli call at all.
 
 **Why OpenConnect needs a helper.** It is the one kind that cannot be brought
 up with `connection up`. Its `cookie`, `gateway`, `gwcert` and `resolve`
@@ -396,7 +396,7 @@ anything can run it. With no eligible profile the backend disappears, and with
 it the chip, the hero, and the empty list they led to; the import instructions
 move to the panel's `setupHint` line so nothing is lost. Because `detected` now
 follows the profile list, the question is settled by `refresh()` rather than by
-`detect()`, which runs its four probes once and is a no-op after that.
+`detect()`, which runs its five probes once and is a no-op after that.
 
 **FILENAME is what keeps other tools' tunnels out.** When something brings up a
 WireGuard interface itself — Mullvad's `wg0-mullvad` — NetworkManager adopts the

--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -4,9 +4,9 @@ import "model/Shared.js" as Shared
 import "model/NetworkManager.js" as NetworkManager
 
 // NetworkManager backend: every tunnel NetworkManager owns, which on a desktop
-// means OpenVPN, WireGuard and OpenConnect. None has a session daemon of its
-// own to ask — NetworkManager is what imports and stores `.ovpn` files,
-// WireGuard configs and AnyConnect profiles alike. Implements the backend
+// means OpenVPN, WireGuard, OpenConnect and VPNC. None has a session daemon of
+// its own to ask — NetworkManager is what imports and stores `.ovpn` files,
+// WireGuard configs and concentrator profiles alike. Implements the backend
 // contract documented in VpnController.qml.
 Item {
   id: root
@@ -17,10 +17,10 @@ Item {
 
   readonly property string backendId: "networkmanager"
   readonly property string label: "NetworkManager"
-  // Three names, because this backend is the only way to reach any of the
+  // Four names, because this backend is the only way to reach any of the
   // protocols and the label names the manager rather than anything you would
   // install.
-  readonly property var installNames: ["OpenVPN", "WireGuard", "OpenConnect"]
+  readonly property var installNames: ["OpenVPN", "WireGuard", "OpenConnect", "VPNC"]
 
   // The helper that authenticates an OpenConnect profile. Resolved here
   // because only the backend knows where the plugin is installed.
@@ -40,11 +40,12 @@ Item {
   property bool _openvpnPresent: false
   property bool _wireguardPresent: false
   property bool _openconnectPresent: false
+  property bool _vpncPresent: false
   property int _probesDone: 0
   property bool _probed: false
 
   readonly property bool _toolsPresent:
-    _nmcliPresent && (_openvpnPresent || _wireguardPresent || _openconnectPresent)
+    _nmcliPresent && (_openvpnPresent || _wireguardPresent || _openconnectPresent || _vpncPresent)
   // Having the tools is not having anything to connect to. NetworkManager is
   // the one backend whose list can be legitimately empty on a working install,
   // and a chip leading to an empty list is a chip worth not drawing.
@@ -88,21 +89,22 @@ Item {
   // the discovery that would settle that question belongs in refresh(), which
   // the controller skips for a hidden tool. Falling through to it here would
   // poll a tool the user switched off. The binaries do not come and go, so once
-  // probed this is nothing rather than three more processes every poll.
+  // probed this is nothing rather than five more processes every poll.
   function detect(force) {
     if (nmcliProbe.running || openvpnProbe.running || wireguardProbe.running
-        || openconnectProbe.running) return
+        || openconnectProbe.running || vpncProbe.running) return
     if (_probed && force !== true) return
     _probesDone = 0
     nmcliProbe.running = true
     openvpnProbe.running = true
     wireguardProbe.running = true
     openconnectProbe.running = true
+    vpncProbe.running = true
   }
 
   function _probeFinished() {
     root._probesDone += 1
-    if (root._probesDone < 4) return
+    if (root._probesDone < 5) return
     root._probed = true
     if (root._toolsPresent) root.refresh()
   }
@@ -118,15 +120,15 @@ Item {
   function connectTo(target) {
     if (!detected || _working || !target) return
 
-    // `nmcli --ask` prompts for secrets only, and the OpenVPN username is not
-    // one — it lives in vpn.data. Without it the profile authenticates as the
-    // empty user and the server rejects it, so point at the fix rather than
+    // `nmcli --ask` prompts for secrets only, and the OpenVPN/VPNC username is
+    // not one — it lives in vpn.data. Without it the profile authenticates as
+    // the empty user and the server rejects it, so point at the fix rather than
     // open a password prompt that cannot succeed. WireGuard has no username at
     // all, and OpenConnect settles identity with the gateway during its own
     // authentication, so this is neither of their problems.
     if (NetworkManager.needsUsername(target) && target.hasUsername === false) {
       lastError = "\"" + target.label + "\" has no username. Set one with: nmcli connection modify "
-        + target.label + " +vpn.data username=<user>"
+        + "uuid " + target.uuid + " +vpn.data '" + NetworkManager.usernameSetting(target) + "=<user>'"
       return
     }
 
@@ -215,6 +217,7 @@ Item {
   function runnable(profile) {
     if (profile.kind === "wireguard") return _wireguardPresent
     if (profile.kind === "openconnect") return _openconnectPresent
+    if (profile.kind === "vpnc") return _vpncPresent
     return _openvpnPresent
   }
 
@@ -306,6 +309,24 @@ Item {
     running: true
     onExited: function(exitCode) {
       root._openconnectPresent = exitCode === 0
+      root._probeFinished()
+    }
+  }
+
+  // NetworkManager's VPNC service is deliberately not on PATH. Distributions
+  // put it in lib or libexec, so checking the carrier itself is more accurate
+  // than checking for the standalone `vpnc` client a profile does not invoke.
+  Process {
+    id: vpncProbe
+    command: ["sh", "-c", [
+      "test -x /usr/lib/nm-vpnc-service",
+      "test -x /usr/libexec/nm-vpnc-service",
+      "test -x /usr/lib/NetworkManager/nm-vpnc-service",
+      "test -x /usr/lib/networkmanager/nm-vpnc-service"
+    ].join(" || ")]
+    running: true
+    onExited: function(exitCode) {
+      root._vpncPresent = exitCode === 0
       root._probeFinished()
     }
   }
@@ -419,10 +440,12 @@ Item {
         if (!detail) continue
 
         // The second pass is where a `vpn` row learns which plugin it is, so
-        // it is also where OpenConnect stops being indistinguishable from
-        // OpenVPN. Everything downstream keys off `kind`.
+        // it is also where OpenConnect and VPNC stop being indistinguishable
+        // from OpenVPN. Everything downstream keys off `kind`.
         if (NetworkManager.isOpenConnectService(detail.serviceType)) {
           candidate.kind = "openconnect"
+        } else if (NetworkManager.isVpncService(detail.serviceType)) {
+          candidate.kind = "vpnc"
         } else if (!NetworkManager.isOpenVpnService(detail.serviceType)) {
           continue
         }

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Omarchy with its Quickshell desktop, plus at least one of:
   (`mullvad account login <number>`).
 - **Windscribe** — `windscribe-cli` with the Windscribe app running, logged in
   (`windscribe-cli login`).
-- **OpenVPN, WireGuard or OpenConnect** — `nmcli`, plus `openvpn`, `wg` (wireguard-tools),
-  or `networkmanager-openconnect`,
+- **OpenVPN, WireGuard, OpenConnect or VPNC** — `nmcli`, plus `openvpn`, `wg`
+  (wireguard-tools), `networkmanager-openconnect`, or `networkmanager-vpnc`,
   with at least one profile imported into NetworkManager.
 
 ## Settings
@@ -173,9 +173,9 @@ terminal costs the panel a moment and nothing more.
 
 <img src="preview-networkmanager.png" alt="The VPN panel on the NetworkManager chip, listing two OpenVPN profiles and one WireGuard profile" width="365">
 
-Neither OpenVPN nor WireGuard has a daemon of its own to ask, so both come from
-NetworkManager — the thing that imports and stores tunnel configs on a desktop.
-They share one chip, and the row icon says which is which. Import one with:
+OpenVPN, WireGuard, OpenConnect and VPNC profiles all come from NetworkManager —
+the thing that imports and stores tunnel configs on a desktop. They share one
+chip, and the row icon says which is which. Import one with:
 
 ```bash
 nmcli connection import type openvpn file ~/Downloads/office.ovpn
@@ -183,9 +183,11 @@ nmcli connection import type wireguard file ~/Downloads/home.conf
 ```
 
 NetworkManager runs on every desktop, so the chip appears only once you have a
-profile it can actually carry — an OpenVPN one with `openvpn` installed, or a
-WireGuard one with `wireguard-tools`. Until then the panel shows the import
-command above rather than a chip leading to an empty list.
+profile it can actually carry — an OpenVPN one with `openvpn` installed, a
+WireGuard one with `wireguard-tools`, an OpenConnect one with
+`networkmanager-openconnect`, or a VPNC one with `networkmanager-vpnc`. Until
+then the panel shows the import command above rather than a chip leading to an
+empty list.
 
 A tunnel you started some other way is not listed: a bare `openvpn` process,
 `openvpn-client@.service`, or a `wg-quick@` unit. Neither is a tunnel another
@@ -218,6 +220,11 @@ Without those, clicking a profile opens a terminal running
 WireGuard needs none of this: its keys live in the profile. The one exception is
 a profile whose `wireguard.private-key-flags` were set to ask an agent, which
 lands in the same terminal.
+
+VPNC profiles follow the OpenVPN credential path, but call their identity
+`Xauth username` and carry both a user password and an IPSec group secret. Save
+both secrets in the NetworkManager profile for a one-click connection; if the
+user password is not saved, the panel opens `nmcli --ask` in a terminal.
 
 If you are importing a Proton `.ovpn`: the username and password are the
 **OpenVPN/IKEv2** credentials from your Proton dashboard, not your Proton

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "VPN",
-    "description": "Detects installed VPN tools (Proton VPN, Mullvad, Windscribe, and NetworkManager's OpenVPN, WireGuard and OpenConnect profiles) and switches between them from one bar icon.",
+    "description": "Detects installed VPN tools (Proton VPN, Mullvad, Windscribe, and NetworkManager's OpenVPN, WireGuard, OpenConnect and VPNC profiles) and switches between them from one bar icon.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",

--- a/model/NetworkManager.js
+++ b/model/NetworkManager.js
@@ -1,17 +1,17 @@
 .pragma library
 .import "Shared.js" as Shared
 
-// OpenVPN and WireGuard profiles, via `nmcli`. Parsing and row-building only —
-// the process plumbing lives in NetworkManagerBackend.qml.
+// OpenVPN, WireGuard, OpenConnect and VPNC profiles, via `nmcli`. Parsing and
+// row-building only — the process plumbing lives in NetworkManagerBackend.qml.
 
 //
-// OpenVPN, WireGuard and OpenConnect all live here, because on a desktop all
-// three are NetworkManager profiles: same listing call, same teardown. What
-// differs is how NetworkManager types them — OpenVPN and OpenConnect are `vpn`
-// connections with a service-type plugin behind them, WireGuard is its own
-// connection type with the keys in the profile.
+// All four live here because on a desktop they are NetworkManager profiles:
+// same listing call, same activation and teardown. What differs is how
+// NetworkManager types them — OpenVPN, OpenConnect and VPNC are `vpn`
+// connections with a service-type plugin behind them, while WireGuard is its
+// own connection type with the keys in the profile.
 //
-// OpenConnect differs from the other two in one way that reaches this file: it
+// OpenConnect differs from the other three in one way that reaches this file: it
 // cannot be brought up with `connection up` alone. Its cookie/gateway/gwcert/
 // resolve secrets are all flagged not-saved, so every activation needs a
 // secret agent to produce them, and the answer is a helper that runs the
@@ -109,7 +109,11 @@ function parseNmcliVpnDetails(raw) {
     else if (pair[0] === "vpn.service-type") current.serviceType = pair[1]
     else if (pair[0] === "vpn.data") {
       current.hasUsername = hasVpnUsername(pair[1])
+      // OpenConnect calls this `gateway`; VPNC inherited the spelling used by
+      // vpnc.conf. Keeping one field downstream lets the detail row stay blind
+      // to the plugin that supplied it.
       current.gateway = vpnDataValue(pair[1], "gateway")
+        || vpnDataValue(pair[1], "IPSec gateway")
     }
   }
   flush()
@@ -132,16 +136,20 @@ function vpnDataValue(data, wanted) {
   return ""
 }
 
-// vpn.data is a comma-separated "key = value" list. OpenVPN's username lives
-// there rather than in vpn.secrets, so `nmcli --ask` never prompts for it —
-// a profile missing it authenticates as the empty user and is rejected.
+// vpn.data is a comma-separated "key = value" list. OpenVPN calls the identity
+// `username`; VPNC calls it `Xauth username`. Both live outside vpn.secrets, so
+// `nmcli --ask` never prompts for either — a profile missing one authenticates
+// as the empty user and is rejected.
 function hasVpnUsername(data) {
   var entries = String(data || "").split(",")
   for (var i = 0; i < entries.length; i++) {
     var entry = entries[i].trim()
-    if (entry.indexOf("username") !== 0) continue
+    var eq = entry.indexOf("=")
+    if (eq === -1) continue
+    var key = entry.substring(0, eq).trim().toLowerCase()
+    if (key !== "username" && key !== "xauth username") continue
 
-    var value = entry.substring(entry.indexOf("=") + 1).trim()
+    var value = entry.substring(eq + 1).trim()
     if (value !== "") return true
   }
   return false
@@ -157,6 +165,10 @@ function isOpenConnectService(serviceType) {
   return String(serviceType || "").toLowerCase().indexOf("openconnect") !== -1
 }
 
+function isVpncService(serviceType) {
+  return String(serviceType || "").toLowerCase().indexOf("networkmanager.vpnc") !== -1
+}
+
 function isWireGuard(profile) {
   return profile && profile.kind === "wireguard"
 }
@@ -165,16 +177,25 @@ function isOpenConnect(profile) {
   return profile && profile.kind === "openconnect"
 }
 
-// A username is an OpenVPN concern only. WireGuard keeps its keys in the
+function isVpnc(profile) {
+  return profile && profile.kind === "vpnc"
+}
+
+// A username is an OpenVPN and VPNC concern. WireGuard keeps its keys in the
 // profile, and OpenConnect asks the gateway who you are as part of its own
 // authentication, so neither can be missing one.
 function needsUsername(profile) {
   return !isWireGuard(profile) && !isOpenConnect(profile)
 }
 
+function usernameSetting(profile) {
+  return isVpnc(profile) ? "Xauth username" : "username"
+}
+
 function nmKindLabel(profile) {
   if (isWireGuard(profile)) return "WireGuard"
   if (isOpenConnect(profile)) return "OpenConnect"
+  if (isVpnc(profile)) return "VPNC"
   return "OpenVPN"
 }
 
@@ -192,19 +213,20 @@ function nmTargets(profiles, authScript) {
     var profile = profiles[i]
     var wireguard = isWireGuard(profile)
     var openconnect = isOpenConnect(profile)
+    var vpnc = isVpnc(profile)
 
     var glyph = Shared.GLYPH_LOCK
     if (wireguard) glyph = Shared.GLYPH_SHIELD
-    else if (openconnect) glyph = Shared.GLYPH_SHIELD_LOCK
+    else if (openconnect || vpnc) glyph = Shared.GLYPH_SHIELD_LOCK
 
     var target = {
       key: "profile:" + profile.uuid,
       label: profile.name,
       detail: profile.active
         ? "Connected"
-        // Only OpenVPN can be missing a username: WireGuard keeps its keys in
-        // the profile, and OpenConnect settles identity with the gateway, so
-        // neither has anything for the user to have left out.
+        // OpenVPN and VPNC keep identity outside their secrets. WireGuard keeps
+        // its keys in the profile, and OpenConnect settles identity with the
+        // gateway, so neither has anything for the user to have left out.
         : (!needsUsername(profile) || profile.hasUsername
             ? nmKindLabel(profile) + " profile"
             : "No username set"),
@@ -238,9 +260,10 @@ function nmDetails(profiles) {
     if (!profiles[i].active) continue
     rows.push(Shared.detail("Profile", profiles[i].name))
     rows.push(Shared.detail("Type", nmKindLabel(profiles[i])))
-    // Which gateway an OpenConnect profile reached, since a company commonly
-    // has several and the profile name rarely says which one.
-    if (isOpenConnect(profiles[i]) && profiles[i].gateway) {
+    // Which gateway an interactive or concentrator-backed profile reached,
+    // since an organisation commonly has several and the profile name rarely
+    // says which one.
+    if ((isOpenConnect(profiles[i]) || isVpnc(profiles[i])) && profiles[i].gateway) {
       rows.push(Shared.detail("Gateway", profiles[i].gateway))
     }
   }

--- a/tests/model/networkmanager.test.js
+++ b/tests/model/networkmanager.test.js
@@ -1,5 +1,5 @@
-// OpenVPN and WireGuard profiles: how `nmcli` formats what it prints, and
-// which rows survive the filtering.
+// OpenVPN, WireGuard, OpenConnect and VPNC profiles: how `nmcli` formats what
+// it prints, and which rows survive the filtering.
 const { test, eq, Shared, NetworkManager } = require("../harness.js")
 
 test("splitNmcliLine splits on the first unescaped colon", () => {
@@ -55,7 +55,9 @@ test("parseNmcliVpnDetails reads one block per connection", () => {
 
 test("hasVpnUsername ignores an empty username", () => {
   eq(NetworkManager.hasVpnUsername("username = alice"), true)
+  eq(NetworkManager.hasVpnUsername("Xauth username = alice"), true)
   eq(NetworkManager.hasVpnUsername("username = "), false)
+  eq(NetworkManager.hasVpnUsername("Xauth username = "), false)
   eq(NetworkManager.hasVpnUsername("comp-lzo = adaptive"), false)
   eq(NetworkManager.hasVpnUsername(""), false)
 })
@@ -109,9 +111,10 @@ test("vpnDataValue matches the whole key, not a prefix", () => {
   eq(NetworkManager.vpnDataValue("", "gateway"), "")
 })
 
-test("nmKindLabel names all three kinds", () => {
+test("nmKindLabel names all four kinds", () => {
   eq(NetworkManager.nmKindLabel({ kind: "wireguard" }), "WireGuard")
   eq(NetworkManager.nmKindLabel({ kind: "openconnect" }), "OpenConnect")
+  eq(NetworkManager.nmKindLabel({ kind: "vpnc" }), "VPNC")
   eq(NetworkManager.nmKindLabel({ kind: "vpn" }), "OpenVPN")
 })
 
@@ -165,6 +168,50 @@ test("nmDetails adds no gateway row for the other kinds", () => {
   ])
   eq(rows.length, 3)
   eq(rows[2], Shared.detail("Managed by", "NetworkManager"))
+})
+
+// -------------------------------------------------------------------- VPNC
+
+// Real `nmcli -t -f connection.uuid,vpn.service-type,vpn.data connection show`
+// shape for a NetworkManager VPNC profile. VPNC's identity and gateway keys
+// deliberately retain the spelling used by vpnc.conf rather than OpenVPN's.
+const VPNC_DETAILS = [
+  "connection.uuid:uuid-vpnc",
+  "vpn.service-type:org.freedesktop.NetworkManager.vpnc",
+  "vpn.data:IKE DH Group = dh2, IPSec ID = staff, IPSec gateway = vpn.example.com, IPSec secret-flags = 0, NAT Traversal Mode = natt, Vendor = cisco, Xauth password-flags = 0, Xauth username = alice",
+  ""
+].join("\n")
+
+test("isVpncService tells VPNC from the other NetworkManager plugins", () => {
+  eq(NetworkManager.isVpncService("org.freedesktop.NetworkManager.vpnc"), true)
+  eq(NetworkManager.isVpncService("org.freedesktop.NetworkManager.openvpn"), false)
+  eq(NetworkManager.isVpncService("org.freedesktop.NetworkManager.openconnect"), false)
+  eq(NetworkManager.isVpncService(""), false)
+})
+
+test("parseNmcliVpnDetails reads VPNC identity and gateway", () => {
+  const detail = NetworkManager.parseNmcliVpnDetails(VPNC_DETAILS)["uuid-vpnc"]
+  eq(detail.hasUsername, true)
+  eq(detail.gateway, "vpn.example.com")
+})
+
+test("nmTargets presents VPNC as an ordinary NetworkManager profile", () => {
+  const targets = NetworkManager.nmTargets([
+    { name: "Campus", uuid: "uuid-vpnc", kind: "vpnc", active: false, hasUsername: true, gateway: "vpn.example.com" }
+  ])
+  eq(targets[0].detail, "VPNC profile")
+  eq(targets[0].glyph, Shared.GLYPH_SHIELD_LOCK)
+  eq(targets[0].args, ["connection", "up", "uuid", "uuid-vpnc"])
+  eq(targets[0].command, undefined)
+  eq(NetworkManager.usernameSetting(targets[0]), "Xauth username")
+})
+
+test("nmDetails names a live VPNC tunnel and its gateway", () => {
+  const rows = NetworkManager.nmDetails([
+    { name: "Campus", uuid: "uuid-vpnc", kind: "vpnc", active: true, gateway: "vpn.example.com" }
+  ])
+  eq(rows[1], Shared.detail("Type", "VPNC"))
+  eq(rows[2], Shared.detail("Gateway", "vpn.example.com"))
 })
 
 test("nmSummary tells no profiles from none connected", () => {


### PR DESCRIPTION
## Summary

- detect and classify NetworkManager VPNC profiles
- recognize VPNC Xauth usernames and IPSec gateways in the widget
- report VPNC client availability and actionable credential guidance
- document the backend support and cover real-format VPNC profiles with tests

## Verification

- `node tests/run.js` — 82 passed, 0 failed
- `omarchy plugin validate .`
- `qmllint -I /usr/share/omarchy/shell jkoestinger.vpn/NetworkManagerBackend.qml`
- verified connect, status detection, and disconnect using a NetworkManager VPNC profile on Omarchy 4.0.0