### PR TITLE
fix: connect certificate-only OpenVPN profiles without a username

### DIFF
--- a/NetworkManagerBackend.qml
+++ b/NetworkManagerBackend.qml
@@ -451,6 +451,7 @@ Item {
         }
 
         candidate.hasUsername = detail.hasUsername
+        candidate.connectionType = detail.connectionType
         candidate.gateway = detail.gateway
         usable.push(candidate)
       }

--- a/model/NetworkManager.js
+++ b/model/NetworkManager.js
@@ -84,7 +84,8 @@ function parseNmcliConnections(raw) {
 
 // `nmcli -t -f connection.uuid,vpn.service-type,vpn.data connection show <uuid>…`
 // prints one blank-line-separated block per connection, each line prefixed
-// with its field name. Returns { uuid: { serviceType, hasUsername, gateway } }.
+// with its field name. Returns
+// { uuid: { serviceType, hasUsername, gateway, connectionType } }.
 function parseNmcliVpnDetails(raw) {
   var details = {}
   var current = null
@@ -103,12 +104,13 @@ function parseNmcliVpnDetails(raw) {
     }
 
     var pair = splitNmcliLine(line)
-    if (!current) current = { uuid: "", serviceType: "", hasUsername: false, gateway: "" }
+    if (!current) current = { uuid: "", serviceType: "", hasUsername: false, gateway: "", connectionType: "" }
 
     if (pair[0] === "connection.uuid") current.uuid = pair[1]
     else if (pair[0] === "vpn.service-type") current.serviceType = pair[1]
     else if (pair[0] === "vpn.data") {
       current.hasUsername = hasVpnUsername(pair[1])
+      current.connectionType = vpnDataValue(pair[1], "connection-type")
       // OpenConnect calls this `gateway`; VPNC inherited the spelling used by
       // vpnc.conf. Keeping one field downstream lets the detail row stay blind
       // to the plugin that supplied it.
@@ -181,11 +183,23 @@ function isVpnc(profile) {
   return profile && profile.kind === "vpnc"
 }
 
+// NetworkManager's OpenVPN plugin records the auth mode in `connection-type`:
+// `tls` authenticates with a certificate and key alone, and `static-key` with a
+// pre-shared key, so neither reads a username — only `password` and
+// `password-tls` do. An Azure point-to-site certificate profile imports as
+// `tls`, and calling that one "no username set" blocks a connection that would
+// have worked.
+function isCertificateOnlyOpenVpn(profile) {
+  var type = String((profile && profile.connectionType) || "").toLowerCase()
+  return type === "tls" || type === "static-key"
+}
+
 // A username is an OpenVPN and VPNC concern. WireGuard keeps its keys in the
 // profile, and OpenConnect asks the gateway who you are as part of its own
 // authentication, so neither can be missing one.
 function needsUsername(profile) {
   return !isWireGuard(profile) && !isOpenConnect(profile)
+    && !isCertificateOnlyOpenVpn(profile)
 }
 
 function usernameSetting(profile) {
@@ -235,6 +249,7 @@ function nmTargets(profiles, authScript) {
       uuid: profile.uuid,
       kind: profile.kind,
       hasUsername: profile.hasUsername,
+      connectionType: profile.connectionType || "",
       gateway: profile.gateway || ""
     }
 

--- a/tests/model/networkmanager.test.js
+++ b/tests/model/networkmanager.test.js
@@ -62,6 +62,40 @@ test("hasVpnUsername ignores an empty username", () => {
   eq(NetworkManager.hasVpnUsername(""), false)
 })
 
+// Real `nmcli -t -f connection.uuid,vpn.service-type,vpn.data` output for an
+// Azure point-to-site profile imported from the gateway's vpnconfig_cert.ovpn.
+// Certificate authentication, so there is no username anywhere in vpn.data.
+const AZURE_CERT_DETAILS = [
+  "connection.uuid:0b7f2c31-9d44-4a1e-8c66-2f5b9a0d1e73",
+  "vpn.service-type:org.freedesktop.NetworkManager.openvpn",
+  "vpn.data:auth = SHA256, ca = /home/user/.local/share/networkmanagement/certificates/nm-openvpn/azure-p2s-ca.pem, cert = /home/user/.local/share/networkmanagement/certificates/nm-openvpn/azure-p2s-cert.pem, challenge-response-flags = 2, cipher = AES-256-GCM, connection-type = tls, data-ciphers = AES-256-GCM:AES-128-GCM:AES-256-CBC, dev = tun, key = /home/user/.local/share/networkmanagement/certificates/nm-openvpn/azure-p2s-key.pem, proto-tcp = yes, remote = azuregateway-1a2b3c4d-5e6f-4718-9abc-def012345678-0123456789ab.vpn.azure.com:443, remote-cert-tls = server, ta = /home/user/.local/share/networkmanagement/certificates/nm-openvpn/azure-p2s-tls-auth.pem, ta-dir = 1, tls-version-min = 1.2, verify-x509-name = name:1a2b3c4d-5e6f-4718-9abc-def012345678.vpn.azure.com"
+].join("\n")
+
+test("parseNmcliVpnDetails reads the OpenVPN auth mode", () => {
+  const detail = NetworkManager.parseNmcliVpnDetails(AZURE_CERT_DETAILS)["0b7f2c31-9d44-4a1e-8c66-2f5b9a0d1e73"]
+  eq(detail.connectionType, "tls")
+  eq(detail.hasUsername, false)
+})
+
+test("a certificate-only OpenVPN profile is not missing a username", () => {
+  // `tls` and `static-key` authenticate without one; only `password` and
+  // `password-tls` read a username, so those are the two that can lack it.
+  eq(NetworkManager.needsUsername({ kind: "vpn", connectionType: "tls" }), false)
+  eq(NetworkManager.needsUsername({ kind: "vpn", connectionType: "static-key" }), false)
+  eq(NetworkManager.needsUsername({ kind: "vpn", connectionType: "password" }), true)
+  eq(NetworkManager.needsUsername({ kind: "vpn", connectionType: "password-tls" }), true)
+  // A profile whose auth mode never got read stays subject to the check.
+  eq(NetworkManager.needsUsername({ kind: "vpn" }), true)
+})
+
+test("nmTargets labels a certificate-only profile by its kind", () => {
+  const targets = NetworkManager.nmTargets([
+    { name: "azure-p2s", uuid: "uuid-tls", kind: "vpn", active: false, hasUsername: false, connectionType: "tls" }
+  ])
+  eq(targets[0].detail, "OpenVPN profile")
+  eq(targets[0].connectionType, "tls")
+})
+
 test("nmTargets flags an OpenVPN profile with no username", () => {
   const targets = NetworkManager.nmTargets([
     { name: "Work", uuid: "uuid-1", kind: "vpn", active: false, hasUsername: false },


### PR DESCRIPTION
Fixes #35.

`needsUsername()` treated every OpenVPN profile as needing a username, so a certificate-only profile was labelled "No username set" and `connectTo()` refused to activate it — pointing at an `nmcli` command that adds a username the profile has no use for. `nmcli connection up` brings the same profile up fine.

NetworkManager's OpenVPN plugin records the auth mode in `connection-type`. Only `password` and `password-tls` read a username; `tls` authenticates with a certificate and key alone, and `static-key` with a pre-shared key — so those two belong with WireGuard and OpenConnect as kinds that cannot be missing one.

### Changes

- `parseNmcliVpnDetails()` reads `connection-type` out of `vpn.data`, alongside the username and gateway it already pulls from there.
- `isCertificateOnlyOpenVpn()` covers `tls` and `static-key`; `needsUsername()` excludes it.
- `connectionType` threaded through the details merge in `NetworkManagerBackend.qml` and onto the target rows, so the panel subtitle and the connect guard read the same value.

A profile whose auth mode was never read still gets the old check, so password profiles are unaffected — that case is asserted in the tests.

### Tests

`node tests/run.js` — 85 passed, 0 failed. Three added:

- `parseNmcliVpnDetails reads the OpenVPN auth mode`
- `a certificate-only OpenVPN profile is not missing a username` — all four `connection-type` values plus the unread case
- `nmTargets labels a certificate-only profile by its kind`

The fixture is real `nmcli -t -f connection.uuid,vpn.service-type,vpn.data` output from an Azure point-to-site profile, with the gateway host and UUID replaced by placeholders of the same shape.

### Checked by hand

Panel connects and disconnects the profile, and the row reads "OpenVPN profile" rather than "No username set". `qmllint` was not available on this machine, so the QML edit — a single property assignment in the existing merge block — is unlinted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)